### PR TITLE
use sigil s for readability

### DIFF
--- a/test/dogma/rules/trailing_whitespace_test.exs
+++ b/test/dogma/rules/trailing_whitespace_test.exs
@@ -36,9 +36,9 @@ defmodule Dogma.Rules.TrailingWhitespaceTest do
 
   with "long lines in triple quote strings" do
     setup context do
-      source = "\"\"\"\n"
-            <> "1 + 1       \n"
-            <> "\"\"\"\n"
+      source = ~s("""\n)
+            <> ~s(1 + 1       \n)
+            <> ~s("""\n)
       script = source |> Script.parse( "foo.ex" )
       %{
         script: TrailingWhitespace.test( script )


### PR DESCRIPTION
Hi, sorry but this is an nit-picking pull request.

Sigil string is more readable than string which has many backslashes, isn't it?