### PR TITLE
Make first argument of mix task a path to test

### DIFF
--- a/lib/dogma.ex
+++ b/lib/dogma.ex
@@ -2,16 +2,16 @@ defmodule Dogma do
   alias Dogma.Script
   alias Dogma.Formatter
 
-  def run do
-    get_scripts
+  def run(dir_path \\ "") do
+    get_scripts(dir_path)
     |> Formatter.start( Formatter.Simple )
     |> test_scripts( Formatter.Simple )
     |> Formatter.finish( Formatter.Simple )
   end
 
 
-  defp get_scripts do
-    Path.wildcard( "**/*.{ex,exs}" )
+  defp get_scripts(dir_path) do
+    Path.wildcard( dir_path <> "**/*.{ex,exs}" )
     |> Enum.reject( &String.starts_with?(&1, "deps/") )
     |> read_paths
   end

--- a/lib/mix/tasks/dogma.ex
+++ b/lib/mix/tasks/dogma.ex
@@ -3,8 +3,16 @@ defmodule Mix.Tasks.Dogma do
 
   @shortdoc "Check Elixir source files for style violations"
 
-  def run(_) do
-    Dogma.run
+  def run(argv) do
+    {_options, arguments, _} = OptionParser.parse(argv)
+    case arguments do
+      [path | _ ]  -> run_dogma(path)
+      []           -> run_dogma("")
+    end
+  end
+
+  defp run_dogma(path) do
+    Dogma.run(path)
     |> any_errors?
     |> if do
       System.halt(666)


### PR DESCRIPTION
Most of the time I'm using tools like this I don't want to run the tests on my test code. Or if I do I'll want to run a different set of rules.

How do you feel about making the first argument given to the mix task restrict the run to a directory path?