### PR TITLE
Stop trailing whitespace test failing on \r\n lines

### DIFF
--- a/lib/dogma/rules/trailing_whitespace.ex
+++ b/lib/dogma/rules/trailing_whitespace.ex
@@ -13,7 +13,8 @@ defmodule Dogma.Rules.TrailingWhitespace do
   end
 
   defp check_line({i, line}, script) do
-    case Regex.run( @regex, line, return: :index ) do
+    trimmed_line = String.replace(line, ~r/\r\z/, "")
+    case Regex.run( @regex, trimmed_line, return: :index ) do
       [{x, _}] -> Script.register_error( script, error(x, i) )
       nil      -> script
     end

--- a/test/dogma/rules/trailing_whitespace_test.exs
+++ b/test/dogma/rules/trailing_whitespace_test.exs
@@ -29,24 +29,17 @@ defmodule Dogma.Rules.TrailingWhitespaceTest do
     ]
   end
 
-  with "windows line endings are okay" do
+  with "lines terminated windows style, \r\n" do
     setup context do
       source = "   'hello'\r\n"
       <> "'how'\r\n"
       <> "  'are'\r\n"
       <> "      'you?'\r\n"
-      <> "'WINDOWS!' \r\n"
       script = source |> Script.parse( "foo.ex" ) |> TrailingWhitespace.test
       %{ script: script }
     end
 
-    should_register_errors [
-      %Error{
-        rule: Dogma.Rules.TrailingWhitespace,
-        message: "Trailing whitespace detected [10]",
-        position: 5
-      }
-    ]
+    should_register_no_errors
   end
 
   with "long lines in triple quote strings" do

--- a/test/dogma/rules/trailing_whitespace_test.exs
+++ b/test/dogma/rules/trailing_whitespace_test.exs
@@ -29,6 +29,26 @@ defmodule Dogma.Rules.TrailingWhitespaceTest do
     ]
   end
 
+  with "windows line endings are okay" do
+    setup context do
+      source = "   'hello'\r\n"
+      <> "'how'\r\n"
+      <> "  'are'\r\n"
+      <> "      'you?'\r\n"
+      <> "'WINDOWS!' \r\n"
+      script = source |> Script.parse( "foo.ex" ) |> TrailingWhitespace.test
+      %{ script: script }
+    end
+
+    should_register_errors [
+      %Error{
+        rule: Dogma.Rules.TrailingWhitespace,
+        message: "Trailing whitespace detected [10]",
+        position: 5
+      }
+    ]
+  end
+
   with "long lines in triple quote strings" do
     setup context do
       source = ~s("""\n)


### PR DESCRIPTION
The trailing whitespace rule fails if any lines are terminated with \r\n. Which is a little confusing as it isn't visible.

Might be worth adding a separate rule to catch any \r\n endings however.