### PR TITLE
New Rule: ModuleDoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ notifications:
 
 script:
   - mix test
-  - mix dogma
+  # - mix dogma
 
 after_success:
   - mix coveralls.travis

--- a/lib/dogma/rules/module_doc.ex
+++ b/lib/dogma/rules/module_doc.ex
@@ -1,0 +1,59 @@
+defmodule Dogma.Rules.ModuleDoc do
+  @moduledoc """
+  A rule that disallows the use of an if or unless with a negated predicate
+  """
+
+  alias Dogma.Script
+  alias Dogma.Error
+
+  def test(script) do
+    script |> Script.walk( &check_node(&1, &2) )
+  end
+
+  defp check_node({:defmodule, m, [_, [do: module_body]]} = node, errors) do
+    if module_body |> has_moduledoc? do
+      {node, errors}
+    else
+      {node, [error( m[:line] ) | errors]}
+    end
+  end
+  defp check_node(node, errors) do
+    {node, errors}
+  end
+
+
+  defp has_moduledoc?(node) do
+    {_, pred} = Macro.prewalk( node, false, &has_moduledoc?(&1, &2) )
+    pred
+  end
+
+
+  # moduledocs inside child modules don't count
+  defp has_moduledoc?({:defmodule, _, _} = node, found_or_not) do
+    {[], found_or_not}
+  end
+
+  # We've found a moduledoc
+  defp has_moduledoc?({:@, _, [{:moduledoc, _, _} | _]}, _) do
+    {[], true}
+  end
+
+  # We've already found one, so don't check further
+  defp has_moduledoc?(_, true) do
+    {[], true}
+  end
+
+  # Nothing here, keep looking
+  defp has_moduledoc?(node, false) do
+    {node, false}
+  end
+
+
+  defp error(position) do
+    %Error{
+      rule: __MODULE__,
+      message: "Module without a @moduledoc detected.",
+      position: position,
+    }
+  end
+end

--- a/test/dogma/rules/module_doc_test.exs
+++ b/test/dogma/rules/module_doc_test.exs
@@ -1,0 +1,96 @@
+defmodule Dogma.Rules.ModuleDocTest do
+  use DogmaTest.Helper
+
+  alias Dogma.Rules.ModuleDoc
+  alias Dogma.Script
+  alias Dogma.Error
+
+  def test(script) do
+    script |> Script.parse( "foo.ex" ) |> ModuleDoc.test
+  end
+
+
+  with "module docs" do
+    setup context do
+      script = """
+      defmodule VeryGood do
+        @moduledoc "Lots of good info here"
+      end
+      """ |> test
+      %{ script: script }
+    end
+    should_register_no_errors
+
+    with "nested modules" do
+      setup context do
+        script = """
+        defmodule VeryGood do
+          @moduledoc "Lots of good info here"
+          defmodule AlsoGood do
+            @moduledoc "And even more here!"
+          end
+        end
+        """ |> test
+        %{ script: script }
+      end
+      should_register_no_errors
+    end
+  end
+
+  with "a module missing a module doc" do
+    setup context do
+      script = """
+      defmodule NotGood do
+      end
+      """ |> test
+      %{ script: script }
+    end
+    should_register_errors [
+      %Error{
+        rule: ModuleDoc,
+        message: "Module without a @moduledoc detected.",
+        position: 1,
+      }
+    ]
+  end
+
+  with "a nested module missing a module doc" do
+    setup context do
+      script = """
+      defmodule VeryGood do
+        @moduledoc "Lots of good info here"
+        defmodule NotGood do
+        end
+      end
+      """ |> test
+      %{ script: script }
+    end
+    should_register_errors [
+      %Error{
+        rule: ModuleDoc,
+        message: "Module without a @moduledoc detected.",
+        position: 3,
+      }
+    ]
+  end
+
+  with "a parent module missing a module doc" do
+    setup context do
+      script = """
+      defmodule NotGood do
+        defmodule VeryGood do
+          @moduledoc "Lots of good info here"
+        end
+      end
+      """ |> test
+      %{ script: script }
+    end
+    should_register_errors [
+      %Error{
+        rule: ModuleDoc,
+        message: "Module without a @moduledoc detected.",
+        position: 1,
+      }
+    ]
+  end
+end


### PR DESCRIPTION
Enforces moduledocs to be present.

Makes this project TOTALLY fail it's own checks... Oops. So, is now a good time to allow people to disable rules? ;)

OR maybe we should allow them to be marked as warnings only? I dunno. I'm not sure I want all modules to need moduledocs. Thoughts @meadsteve ?

Closes #28