### PR TITLE
Make skipping exs files available to all tests

### DIFF
--- a/lib/dogma/rules/debugger_statement.ex
+++ b/lib/dogma/rules/debugger_statement.ex
@@ -7,7 +7,7 @@ defmodule Dogma.Rules.DebuggerStatement do
   alias Dogma.Script
   alias Dogma.Error
 
-  def test(script) do
+  def test(script, _config \\ []) do
     script |> Script.walk( &check_node(&1, &2) )
   end
 

--- a/lib/dogma/rules/final_newline.ex
+++ b/lib/dogma/rules/final_newline.ex
@@ -6,7 +6,7 @@ defmodule Dogma.Rules.FinalNewline do
   alias Dogma.Script
   alias Dogma.Error
 
-  def test(script) do
+  def test(script, _config \\ []) do
     if script.source |> String.ends_with?("\n") do
       script
     else

--- a/lib/dogma/rules/function_arity.ex
+++ b/lib/dogma/rules/function_arity.ex
@@ -6,11 +6,8 @@ defmodule Dogma.Rules.FunctionArity do
   alias Dogma.Script
   alias Dogma.Error
 
-  def test(script) do
-    test(script, max: 4)
-  end
-
-  def test(script, max: max) do
+  def test(script, options \\ []) do
+    max = options |> Keyword.get(:max, 4)
     script
       |> Script.walk( fn(node, errs) -> check_node(node, errs, max) end)
   end

--- a/lib/dogma/rules/function_name.ex
+++ b/lib/dogma/rules/function_name.ex
@@ -7,7 +7,7 @@ defmodule Dogma.Rules.FunctionName do
   alias Dogma.Error
   alias Dogma.Util.Name
 
-  def test(script) do
+  def test(script, _config \\ []) do
     script |> Script.walk( &check_node(&1, &2) )
   end
 

--- a/lib/dogma/rules/line_length.ex
+++ b/lib/dogma/rules/line_length.ex
@@ -6,11 +6,8 @@ defmodule Dogma.Rules.LineLength do
   alias Dogma.Script
   alias Dogma.Error
 
-  def test(script) do
-    test(script, max_length: 80)
-  end
-
-  def test(script, max_length: max) do
+  def test(script, options \\ []) do
+    max = options |> Keyword.get(:max_length, 80)
     script.lines
     |> Enum.filter(fn ({_, line}) -> String.length(line) > max end)
     |> Enum.reduce(script, &add_line_error/2)

--- a/lib/dogma/rules/literal_in_condition.ex
+++ b/lib/dogma/rules/literal_in_condition.ex
@@ -7,7 +7,7 @@ defmodule Dogma.Rules.LiteralInCondition do
   alias Dogma.Script
   alias Dogma.Error
 
-  def test(script) do
+  def test(script, _config \\ []) do
     script |> Script.walk( &check_node(&1, &2) )
   end
 

--- a/lib/dogma/rules/module_attribute_name.ex
+++ b/lib/dogma/rules/module_attribute_name.ex
@@ -7,7 +7,7 @@ defmodule Dogma.Rules.ModuleAttributeName do
   alias Dogma.Error
   alias Dogma.Util.Name
 
-  def test(script) do
+  def test(script, _config \\ []) do
     script |> Script.walk( &check_node(&1, &2) )
   end
 

--- a/lib/dogma/rules/module_doc.ex
+++ b/lib/dogma/rules/module_doc.ex
@@ -8,14 +8,8 @@ defmodule Dogma.Rules.ModuleDoc do
   alias Dogma.Script
   alias Dogma.Error
 
-  @file_to_be_skipped ~r/\.exs\z/
-
-  def test(script) do
-    if Regex.match?( @file_to_be_skipped, script.path ) do
-      script
-    else
-      script |> Script.walk( &check_node(&1, &2) )
-    end
+  def test(script, _config \\ []) do
+    script |> Script.walk( &check_node(&1, &2) )
   end
 
   defp check_node({:defmodule, m, [_, [do: module_body]]} = node, errors) do

--- a/lib/dogma/rules/module_name.ex
+++ b/lib/dogma/rules/module_name.ex
@@ -7,7 +7,7 @@ defmodule Dogma.Rules.ModuleName do
   alias Dogma.Error
   alias Dogma.Util.Name
 
-  def test(script) do
+  def test(script, _config \\ []) do
     script |> Script.walk( &check_node(&1, &2) )
   end
 

--- a/lib/dogma/rules/negated_if_unless.ex
+++ b/lib/dogma/rules/negated_if_unless.ex
@@ -6,7 +6,7 @@ defmodule Dogma.Rules.NegatedIfUnless do
   alias Dogma.Script
   alias Dogma.Error
 
-  def test(script) do
+  def test(script, _config \\ []) do
     script |> Script.walk( &check_node(&1, &2) )
   end
 

--- a/lib/dogma/rules/quotes_in_string.ex
+++ b/lib/dogma/rules/quotes_in_string.ex
@@ -7,7 +7,7 @@ defmodule Dogma.Rules.QuotesInString do
   alias Dogma.Script
   alias Dogma.Error
 
-  def test(script) do
+  def test(script, _config \\ []) do
     script |> Script.walk( &check_node(&1, &2) )
   end
 

--- a/lib/dogma/rules/sets/all.ex
+++ b/lib/dogma/rules/sets/all.ex
@@ -14,7 +14,7 @@ defmodule Dogma.Rules.Sets.All do
       {LineLength, max_length: 80},
       {LiteralInCondition},
       {ModuleAttributeName},
-      {ModuleDoc},
+      {ModuleDoc, skip_exs_files: true},
       {ModuleName},
       {NegatedIfUnless},
       {QuotesInString},

--- a/lib/dogma/rules/trailing_blank_lines.ex
+++ b/lib/dogma/rules/trailing_blank_lines.ex
@@ -8,7 +8,7 @@ defmodule Dogma.Rules.TrailingBlankLines do
 
   @violation_regex ~r/\n\n+\z/
 
-  def test(script) do
+  def test(script, _config \\ []) do
     case script |> violation? do
       false -> script
       pos   -> script |> add_error( pos )

--- a/lib/dogma/rules/trailing_whitespace.ex
+++ b/lib/dogma/rules/trailing_whitespace.ex
@@ -8,7 +8,7 @@ defmodule Dogma.Rules.TrailingWhitespace do
 
   @regex ~r/\s+\z/
 
-  def test(script) do
+  def test(script, _config \\ []) do
     Enum.reduce( script.lines, script, &check_line(&1, &2) )
   end
 

--- a/lib/dogma/rules/unless_else.ex
+++ b/lib/dogma/rules/unless_else.ex
@@ -6,7 +6,7 @@ defmodule Dogma.Rules.UnlessElse do
   alias Dogma.Script
   alias Dogma.Error
 
-  def test(script) do
+  def test(script, _config \\ []) do
     script |> Script.walk( &check_node(&1, &2) )
   end
 

--- a/lib/dogma/rules/variable_name.ex
+++ b/lib/dogma/rules/variable_name.ex
@@ -7,7 +7,7 @@ defmodule Dogma.Rules.VariableName do
   alias Dogma.Error
   alias Dogma.Util.Name
 
-  def test(script) do
+  def test(script, _config \\ []) do
     script |> Script.walk( &check_node(&1, &2) )
   end
 

--- a/lib/dogma/rules/windows_line_endings.ex
+++ b/lib/dogma/rules/windows_line_endings.ex
@@ -8,7 +8,7 @@ defmodule Dogma.Rules.WindowsLineEndings do
 
   @violation_regex ~r/\r\z/
 
-  def test(script) do
+  def test(script, _config \\ []) do
     Enum.reduce( script.lines, script, &check_line(&1, &2) )
   end
 

--- a/lib/dogma/script.ex
+++ b/lib/dogma/script.ex
@@ -8,6 +8,7 @@ defmodule Dogma.Script do
   alias Dogma.Rules
   alias Dogma.Script
   alias Dogma.Error
+  alias Dogma.Script.Skipper
 
   defstruct path:   nil,
             source: nil,
@@ -40,8 +41,16 @@ defmodule Dogma.Script do
   """
   def run_tests(script, rule_module \\ nil) do
     (rule_module || Rules.Sets.All).list()
+    |> Enum.reject(fn(rule) -> skip_test?(rule, script) end)
     |> Enum.map(&namespace_rule/1)
     |> Enum.reduce( script, &run_test/2 )
+  end
+
+  defp skip_test?({_, config}, script) do
+    script |> Skipper.skip?(config)
+  end
+  defp skip_test?(_, _) do
+    false
   end
 
   defp namespace_rule({rule, custom_config}) do

--- a/lib/dogma/script/skipper.ex
+++ b/lib/dogma/script/skipper.ex
@@ -5,12 +5,9 @@ defmodule Dogma.Script.Skipper do
 
   @exs_file ~r/\.exs\z/
 
-  def skip?(script, skip_exs_files: true) do
-    Regex.match?( @exs_file, script.path )
-  end
-
-  def skip?(script, _) do
-    false
+  def skip?(script, options \\ []) do
+    skip_exs? = options |> Keyword.get(:skip_exs_files, false)
+    skip_exs? && Regex.match?( @exs_file, script.path )
   end
 
 end

--- a/lib/dogma/script/skipper.ex
+++ b/lib/dogma/script/skipper.ex
@@ -1,0 +1,16 @@
+defmodule Dogma.Script.Skipper do
+  @moduledoc """
+  Uses general config to determine if a file should be skipped.
+  """
+
+  @exs_file ~r/\.exs\z/
+
+  def skip?(script, skip_exs_files: true) do
+    Regex.match?( @exs_file, script.path )
+  end
+
+  def skip?(script, _) do
+    false
+  end
+
+end

--- a/test/dogma/script/skipper_test.exs
+++ b/test/dogma/script/skipper_test.exs
@@ -1,0 +1,40 @@
+defmodule Dogma.Script.SkipperTest do
+  use ShouldI
+
+  alias Dogma.Script
+  alias Dogma.Script.Skipper
+
+  with "an exs file" do
+
+    setup context do
+      %{
+        script: Script.parse( "1 + 1", "foo.exs" )
+      }
+    end
+
+    should "be skipped if configured", context do
+      skipped? = context.script |> Skipper.skip?(skip_exs_files: true)
+      assert skipped? == true
+    end
+
+    should "not be skipped if the config flag isn't set", context do
+      skipped? = context.script |> Skipper.skip?([something: "else"])
+      assert skipped? == false
+    end
+  end
+
+  with "an ex file" do
+
+    setup context do
+      %{
+        script: Script.parse( "1 + 1", "foo.ex" )
+      }
+    end
+
+    should "not be skipped if the config for exs files is set", context do
+      skipped? = context.script |> Skipper.skip?(skip_exs_files: true)
+      assert skipped? == false
+    end
+  end
+
+end


### PR DESCRIPTION
So this seemed like the easiest way to implement #44 .
Basically each rule can now have the config: ```skip_exs_files: true``` and it won't run for exs files.

Thoughts?