### PR TITLE
Fix function_name rule when functions are named with unquote(_)

### DIFF
--- a/lib/dogma/rules/function_name.ex
+++ b/lib/dogma/rules/function_name.ex
@@ -22,6 +22,11 @@ defmodule Dogma.Rules.FunctionName do
     {node, errors}
   end
 
+  # If the function is named by unquoting something then we can't check it
+  defp check_function({:unquote,_,_} , _meta, node, errors) do
+    {node, errors}
+  end
+
   defp check_function(name, meta, node, errors) do
     if name |> to_string |> Name.probably_snake_case? do
       {node, errors}

--- a/test/dogma/rules/function_name_test.exs
+++ b/test/dogma/rules/function_name_test.exs
@@ -30,6 +30,18 @@ defmodule Dogma.Rules.FunctionNameTest do
     should_register_no_errors
   end
 
+  with "valid but weird names" do
+    setup context do
+      script = """
+      def unquote(function_name)(_state) do
+        {:ok, "something"}
+      end
+      """ |> test
+      %{ script: script }
+    end
+    should_register_no_errors
+  end
+
   with "invalid names using def" do
     setup context do
       script = """


### PR DESCRIPTION
Ran in to some code like
```elixir
  def unquote(some_thing)(args) do
    #...
  end
```
This caused an error as the function_name rule was expecting a string. I've modified the rule so it skips any thing like this.