### PR TITLE
Run rules on a script in parallel

### DIFF
--- a/lib/dogma/script.ex
+++ b/lib/dogma/script.ex
@@ -50,7 +50,8 @@ defmodule Dogma.Script do
   def run_tests(script, rule_module \\ nil) do
     (rule_module || Rules.Sets.All).list()
     |> Enum.map( &namespace_rule/1 )
-    |> Enum.map( &run_test(&1, script) )
+    |> Enum.map( &Task.async(fn -> run_test(&1, script) end) )
+    |> Enum.map( &Task.await(&1) )
     |> List.flatten
   end
 


### PR DESCRIPTION
This actually seems to negatively impact performance...

Using [this](https://github.com/lpil/dogma/blob/master/bench/single_file_bench.exs) benchmark:

| Bench     | Typical result |
| --------- | -------------- |
| Series    | 204.51 µs/op   |
| Parallel  | 445.52 µs/op   |

I guess we shouldn't run things in parallel when we're not actually doing anything that expensive? I think I may have made an assumption about the amount of computation required to make it break even, much like when I was playing with the `Stream` module.

Or am I doing something wrong?

@meadsteve @jonnyarnold