### PR TITLE
Add predicate check - solves #48

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -14,6 +14,7 @@ These are the rules included in Dogma by default.
 * [ModuleDoc](https://github.com/lpil/dogma/blob/master/docs/rules.md#moduledoc)
 * [ModuleName](https://github.com/lpil/dogma/blob/master/docs/rules.md#modulename)
 * [NegatedIfUnless](https://github.com/lpil/dogma/blob/master/docs/rules.md#negatedifunless)
+* [PredicateName](https://github.com/lpil/dogma/blob/master/docs/rules.md#predicatename)
 * [QuotesInString](https://github.com/lpil/dogma/blob/master/docs/rules.md#quotesinstring)
 * [TrailingBlankLines](https://github.com/lpil/dogma/blob/master/docs/rules.md#trailingblanklines)
 * [TrailingWhitespace](https://github.com/lpil/dogma/blob/master/docs/rules.md#trailingwhitespace)
@@ -76,6 +77,11 @@ A rule that disallows module names not in PascalCase
 ### NegatedIfUnless
 
 A rule that disallows the use of an if or unless with a negated predicate
+
+
+### PredicateName
+
+A rule that disallows tautological predicate names.
 
 
 ### QuotesInString

--- a/lib/dogma/rules/module_doc.ex
+++ b/lib/dogma/rules/module_doc.ex
@@ -21,7 +21,7 @@ defmodule Dogma.Rules.ModuleDoc do
   end
 
   defp check_node({:defmodule, m, [_, [do: module_body]]} = node, errors) do
-    if module_body |> has_moduledoc? do
+    if module_body |> moduledoc? do
       {node, errors}
     else
       {node, [error( m[:line] ) | errors]}
@@ -32,32 +32,30 @@ defmodule Dogma.Rules.ModuleDoc do
   end
 
 
-  defp has_moduledoc?(node) do
-    {_, pred} = Macro.prewalk( node, false, &has_moduledoc?(&1, &2) )
+  defp moduledoc?(node) do
+    {_, pred} = Macro.prewalk( node, false, &moduledoc?(&1, &2) )
     pred
   end
 
-
   # moduledocs inside child modules don't count
-  defp has_moduledoc?({:defmodule, _, _}, found_or_not) do
+  defp moduledoc?({:defmodule, _, _}, found_or_not) do
     {[], found_or_not}
   end
 
   # We've found a moduledoc
-  defp has_moduledoc?({:@, _, [{:moduledoc, _, _} | _]}, _) do
+  defp moduledoc?({:@, _, [{:moduledoc, _, _} | _]}, _) do
     {[], true}
   end
 
   # We've already found one, so don't check further
-  defp has_moduledoc?(_, true) do
+  defp moduledoc?(_, true) do
     {[], true}
   end
 
   # Nothing here, keep looking
-  defp has_moduledoc?(node, false) do
+  defp moduledoc?(node, false) do
     {node, false}
   end
-
 
   defp error(position) do
     %Error{

--- a/lib/dogma/rules/module_doc.ex
+++ b/lib/dogma/rules/module_doc.ex
@@ -31,7 +31,6 @@ defmodule Dogma.Rules.ModuleDoc do
     {node, errors}
   end
 
-
   defp moduledoc?(node) do
     {_, pred} = Macro.prewalk( node, false, &moduledoc?(&1, &2) )
     pred

--- a/lib/dogma/rules/predicate_name.ex
+++ b/lib/dogma/rules/predicate_name.ex
@@ -1,0 +1,52 @@
+defmodule Dogma.Rules.PredicateName do
+  @moduledoc """
+  A rule that disallows tautological predicate names.
+  """
+
+  @behaviour Dogma.Rule
+  alias Dogma.Script
+  alias Dogma.Error
+
+  def test(script) do
+    script |> Script.walk( &check_node(&1, &2) )
+  end
+
+  defp check_node({:def, _, [{name, meta, _}|_]} = node, errors) do
+    test_predicate(name, meta, node, errors)
+  end
+  defp check_node({:defp, _, [{name, meta, _}|_]} = node, errors) do
+    test_predicate(name, meta, node, errors)
+  end
+  defp check_node(node, errors) do
+    {node, errors}
+  end
+
+  defp test_predicate(line) do
+    Regex.run(~r{(is|has)_(\w+)\?}, line)
+  end
+
+  defp tautological_predicate?(line) do
+    !!(test_predicate(line))
+  end
+
+  defp test_predicate({:unquote,_,_} , _meta, node, errors) do
+    {node, errors}
+  end
+
+  defp test_predicate(function_name, meta, node, errors) do
+    name = function_name |> to_string
+    if name |> tautological_predicate? do
+      {node, [error( meta[:line], test_predicate(name) ) | errors]}
+    else
+      {node, errors}
+    end
+  end
+
+  defp error(pos, [name, _prefix, suffix]) do
+    %Error{
+      rule:     __MODULE__,
+      message:  "Favour `#{suffix}?` over `#{name}`",
+      position: pos,
+    }
+  end
+end

--- a/lib/dogma/rules/predicate_name.ex
+++ b/lib/dogma/rules/predicate_name.ex
@@ -22,11 +22,7 @@ defmodule Dogma.Rules.PredicateName do
   end
 
   defp test_predicate(line) do
-    Regex.run(~r{(is|has)_(\w+)\?}, line)
-  end
-
-  defp tautological_predicate?(line) do
-    !!(test_predicate(line))
+    Regex.run(~r{\A(is|has)_(\w+)\?\Z}, line)
   end
 
   defp test_predicate({:unquote,_,_} , _meta, node, errors) do
@@ -34,9 +30,9 @@ defmodule Dogma.Rules.PredicateName do
   end
 
   defp test_predicate(function_name, meta, node, errors) do
-    name = function_name |> to_string
-    if name |> tautological_predicate? do
-      {node, [error( meta[:line], test_predicate(name) ) | errors]}
+    name = function_name |> to_string |> test_predicate
+    if name do
+      {node, [error( meta[:line], name ) | errors]}
     else
       {node, errors}
     end

--- a/lib/dogma/rules/sets/all.ex
+++ b/lib/dogma/rules/sets/all.ex
@@ -17,6 +17,7 @@ defmodule Dogma.Rules.Sets.All do
       {ModuleDoc},
       {ModuleName},
       {NegatedIfUnless},
+      {PredicateName},
       {QuotesInString},
       {TrailingBlankLines},
       {TrailingWhitespace},

--- a/test/dogma/rules/predicate_name_test.exs
+++ b/test/dogma/rules/predicate_name_test.exs
@@ -1,0 +1,62 @@
+defmodule Dogma.Rules.PredicateNameTest do
+  use DogmaTest.Helper
+
+  alias Dogma.Rules.PredicateName
+  alias Dogma.Script
+  alias Dogma.Error
+
+  with "bad predicates" do
+    setup context do
+      errors = [
+        """
+        def is_naughty?(arg) do
+          true
+        end
+        """,
+        """
+        defp is_bad?() do
+          true
+        end
+        """
+      ]
+      |> Enum.join( "\n" )
+      |> Script.parse( "foo.ex" )
+      |> PredicateName.test
+      %{ errors: errors }
+    end
+    should_register_errors [
+      %Error{
+        rule: PredicateName,
+        message: "Favour `bad?` over `is_bad?`",
+        position: 5,
+      },
+      %Error{
+        rule: PredicateName,
+        message: "Favour `naughty?` over `is_naughty?`",
+        position: 1,
+      },
+    ]
+  end
+
+  with "good predicates" do
+    setup context do
+      errors = [
+        """
+        def nice?(arg) do
+          true
+        end
+        """,
+        """
+        defp is_nice() do
+          true
+        end
+        """
+      ]
+      |> Enum.join( "\n" )
+      |> Script.parse( "foo.ex" )
+      |> PredicateName.test
+      %{ errors: errors }
+    end
+    should_register_no_errors
+  end
+end


### PR DESCRIPTION
I hope this PR matches your code & testing style closely enough!  I had a look at the Rubocop implementation of this rule and found it quite unwieldy. Hopefully the Regex I've used is strong enough.

I also added the `is_something` style into the 'good' list, as there's a few native functions that use it. I have no idea why, but as long as the function name's not trying to be both I figured it was fine. 

:bow: