### PR TITLE
New Rule: Comparison to Booleans

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -4,6 +4,7 @@ These are the rules included in Dogma by default.
 
 ## Contents
 
+* [ComparisonToBoolean](https://github.com/lpil/dogma/blob/master/docs/rules.md#comparisontoboolean)
 * [DebuggerStatement](https://github.com/lpil/dogma/blob/master/docs/rules.md#debuggerstatement)
 * [FinalNewline](https://github.com/lpil/dogma/blob/master/docs/rules.md#finalnewline)
 * [FunctionArity](https://github.com/lpil/dogma/blob/master/docs/rules.md#functionarity)
@@ -23,6 +24,11 @@ These are the rules included in Dogma by default.
 
 
 ---
+
+### ComparisonToBoolean
+
+A rule that disallows comparison to booleans.
+
 
 ### DebuggerStatement
 

--- a/lib/dogma/rules/comparison_to_boolean.ex
+++ b/lib/dogma/rules/comparison_to_boolean.ex
@@ -1,0 +1,33 @@
+defmodule Dogma.Rules.ComparisonToBoolean do
+  @moduledoc """
+  A rule that disallows comparison to booleans.
+  """
+
+  @behaviour Dogma.Rule
+
+  alias Dogma.Script
+  alias Dogma.Error
+
+  def test(script) do
+    script |> Script.walk( &check_node(&1, &2) )
+  end
+
+  for fun <- [:==, :===, :!=, :!==] do
+    defp check_node({unquote(fun), meta, [lhs, rhs]}, errors)
+    when is_boolean(lhs) or is_boolean(rhs) do
+      {node, [error(meta[:line]) | errors]}
+    end
+  end
+
+  defp check_node(node, errors) do
+    {node, errors}
+  end
+
+  defp error(pos) do
+    %Error{
+      rule: __MODULE__,
+      message: "Comparison to a boolean is pointless",
+      position: pos
+    }
+  end
+end

--- a/lib/dogma/rules/comparison_to_boolean.ex
+++ b/lib/dogma/rules/comparison_to_boolean.ex
@@ -26,7 +26,7 @@ defmodule Dogma.Rules.ComparisonToBoolean do
   defp error(pos) do
     %Error{
       rule: __MODULE__,
-      message: "Comparison to a boolean is pointless",
+      message: "Comparison to a boolean is usually pontless",
       position: pos
     }
   end

--- a/lib/dogma/rules/sets/all.ex
+++ b/lib/dogma/rules/sets/all.ex
@@ -7,6 +7,7 @@ defmodule Dogma.Rules.Sets.All do
 
   def list do
     [
+      {ComparisonToBoolean},
       {DebuggerStatement},
       {FinalNewline},
       {FunctionArity, max: 4},

--- a/test/dogma/rules/comparison_to_boolean_test.exs
+++ b/test/dogma/rules/comparison_to_boolean_test.exs
@@ -1,0 +1,59 @@
+defmodule Dogma.Rules.ComparisonToBooleanTest do
+  @comp [:==, :===, :!=, :!==]
+  @bools [true, false]
+
+  use DogmaTest.Helper
+
+  alias Dogma.Rules.ComparisonToBoolean
+  alias Dogma.Script
+  alias Dogma.Error
+
+  def test(script) do
+    script
+    |> Script.parse("foo.ex")
+    |> ComparisonToBoolean.test
+  end
+
+  def errors(count) do
+    for line_no <- (count..1) do
+      %Error{
+        rule: ComparisonToBoolean,
+        message: "Comparison to a boolean is pointless",
+        position: line_no
+      }
+    end
+  end
+
+  with "lefthand booleans" do
+    setup context do
+      errors = for fun <- @comp, bool <- @bools, into: "" do
+        "foo #{fun} #{bool}\n"
+      end |> test
+      %{errors: errors}
+    end
+
+    errors(8) |> should_register_errors
+  end
+
+  with "righthand booleans" do
+    setup context do
+      errors = for fun <- @comp, bool <- @bools, into: "" do
+        "#{bool} #{fun} foo\n"
+      end |> test
+      %{errors: errors}
+    end
+
+    errors(8) |> should_register_errors
+  end
+
+  with "vars on both sides" do
+    setup context do
+      errors = for fun <- @comp, into: "" do
+        "foo #{fun} bar\n"
+      end |> test
+      %{errors: errors}
+    end
+
+    should_register_no_errors
+  end
+end

--- a/test/dogma/rules/comparison_to_boolean_test.exs
+++ b/test/dogma/rules/comparison_to_boolean_test.exs
@@ -18,7 +18,7 @@ defmodule Dogma.Rules.ComparisonToBooleanTest do
     for line_no <- (count..1) do
       %Error{
         rule: ComparisonToBoolean,
-        message: "Comparison to a boolean is pointless",
+        message: "Comparison to a boolean is usually pontless",
         position: line_no
       }
     end


### PR DESCRIPTION
Enforces no comparison to booleans.

Though, this may be better as a warning since the user may actually want to make sure a variable is explicitly `true` or `false` rather than just truthy or falsey. Thoughts?

Closes #45 