### PR TITLE
New Rule: Comparison to Booleans

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,10 +1,11 @@
 # Dogma Rules
 
 These are the rules included in Dogma by default. Currently there are
-17 of them.
+18 of them.
 
 ## Contents
 
+* [ComparisonToBoolean](https://github.com/lpil/dogma/blob/master/docs/rules.md#comparisontoboolean)
 * [DebuggerStatement](https://github.com/lpil/dogma/blob/master/docs/rules.md#debuggerstatement)
 * [FinalNewline](https://github.com/lpil/dogma/blob/master/docs/rules.md#finalnewline)
 * [FunctionArity](https://github.com/lpil/dogma/blob/master/docs/rules.md#functionarity)
@@ -25,6 +26,11 @@ These are the rules included in Dogma by default. Currently there are
 
 
 ---
+
+### ComparisonToBoolean
+
+A rule that disallows comparison to booleans.
+
 
 ### DebuggerStatement
 

--- a/lib/dogma/rule_set/all.ex
+++ b/lib/dogma/rule_set/all.ex
@@ -7,6 +7,7 @@ defmodule Dogma.RuleSet.All do
 
   def list do
     [
+      {ComparisonToBoolean},
       {DebuggerStatement},
       {FinalNewline},
       {FunctionArity, max: 4},

--- a/lib/dogma/rules/comparison_to_boolean.ex
+++ b/lib/dogma/rules/comparison_to_boolean.ex
@@ -1,0 +1,33 @@
+defmodule Dogma.Rules.ComparisonToBoolean do
+  @moduledoc """
+  A rule that disallows comparison to booleans.
+  """
+
+  @behaviour Dogma.Rule
+
+  alias Dogma.Script
+  alias Dogma.Error
+
+  def test(script) do
+    script |> Script.walk( &check_node(&1, &2) )
+  end
+
+  for fun <- [:==, :===, :!=, :!==] do
+    defp check_node({unquote(fun), meta, [lhs, rhs]}, errors)
+    when is_boolean(lhs) or is_boolean(rhs) do
+      {node, [error(meta[:line]) | errors]}
+    end
+  end
+
+  defp check_node(node, errors) do
+    {node, errors}
+  end
+
+  defp error(pos) do
+    %Error{
+      rule:    __MODULE__,
+      message: "Comparison to a boolean is pointless",
+      line:    pos
+    }
+  end
+end

--- a/test/dogma/rules/comparison_to_boolean_test.exs
+++ b/test/dogma/rules/comparison_to_boolean_test.exs
@@ -1,0 +1,110 @@
+defmodule Dogma.Rules.ComparisonToBooleanTest do
+  use DogmaTest.Helper
+
+  alias Dogma.Rules.ComparisonToBoolean
+  alias Dogma.Script
+  alias Dogma.Error
+
+  @errors [
+    %Error{
+      rule:    ComparisonToBoolean,
+      message: "Comparison to a boolean is pointless",
+      line:    8
+    },
+    %Error{
+      rule:    ComparisonToBoolean,
+      message: "Comparison to a boolean is pointless",
+      line:    7
+    },
+    %Error{
+      rule:    ComparisonToBoolean,
+      message: "Comparison to a boolean is pointless",
+      line:    6
+    },
+    %Error{
+      rule:    ComparisonToBoolean,
+      message: "Comparison to a boolean is pointless",
+      line:    5
+    },
+    %Error{
+      rule:    ComparisonToBoolean,
+      message: "Comparison to a boolean is pointless",
+      line:    4
+    },
+    %Error{
+      rule:    ComparisonToBoolean,
+      message: "Comparison to a boolean is pointless",
+      line:    3
+    },
+    %Error{
+      rule:    ComparisonToBoolean,
+      message: "Comparison to a boolean is pointless",
+      line:    2
+    },
+    %Error{
+      rule:    ComparisonToBoolean,
+      message: "Comparison to a boolean is pointless",
+      line:    1
+    }
+  ]
+
+  def test(script) do
+    script
+    |> Script.parse("foo.ex")
+    |> ComparisonToBoolean.test
+  end
+
+  with "right hand booleans" do
+    setup context do
+      errors = """
+      foo ==  false
+      foo ==  true
+      foo === false
+      foo === true
+      foo !=  false
+      foo !=  true
+      foo !== false
+      foo !== true
+      """ |> test
+      %{errors: errors}
+    end
+
+    should_register_errors @errors
+  end
+
+  with "righthand booleans" do
+    setup context do
+      errors = """
+      true  ==  foo
+      true  === foo
+      true  !=  foo
+      true  !== foo
+      false ==  foo
+      false === foo
+      false !=  foo
+      false !== foo
+      """ |> test
+      %{errors: errors}
+    end
+
+    should_register_errors @errors
+  end
+
+  with "vars on both sides" do
+    setup context do
+      errors = """
+      foo ==  bar
+      foo === bar
+      foo !=  bar
+      foo !== bar
+      foo ==  bar
+      foo === bar
+      foo !=  bar
+      foo !== bar
+      """ |> test
+      %{errors: errors}
+    end
+
+    should_register_no_errors
+  end
+end

--- a/test/dogma/script_test.exs
+++ b/test/dogma/script_test.exs
@@ -67,7 +67,7 @@ defmodule Dogma.ScriptTest do
       end
 
       should "assign valid? as true", context do
-        assert true == context.script.valid?
+        assert context.script.valid?
       end
 
       should "assigns the quoted abstract syntax tree", context do
@@ -93,7 +93,7 @@ defmodule Dogma.ScriptTest do
       end
 
       should "assign valid? as false", context do
-        assert false == context.script.valid?
+        refute context.script.valid?
       end
 
       should "assign [] in place of AST", context do


### PR DESCRIPTION
Enforces no comparisons to booleans.

The repo fails in two places with this test. It's possible the user wants to ensure something is literally `true` or `false` instead of just truthy or falsy. Maybe this should be a warning? Thoughts?

Closes #45 