### PR TITLE
New Rule: Enforce bare variables starting fn chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /deps
 erl_crash.dump
 *.ez
+*.beam
 /doc/
 /docs/all.json
 /bench/snapshots

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,10 +1,11 @@
 # Dogma Rules
 
 These are the rules included in Dogma by default. Currently there are
-18 of them.
+19 of them.
 
 ## Contents
 
+* [BarePipeChainStart](https://github.com/lpil/dogma/blob/master/docs/rules.md#barepipechainstart)
 * [ComparisonToBoolean](https://github.com/lpil/dogma/blob/master/docs/rules.md#comparisontoboolean)
 * [DebuggerStatement](https://github.com/lpil/dogma/blob/master/docs/rules.md#debuggerstatement)
 * [FinalNewline](https://github.com/lpil/dogma/blob/master/docs/rules.md#finalnewline)
@@ -26,6 +27,11 @@ These are the rules included in Dogma by default. Currently there are
 
 
 ---
+
+### BarePipeChainStart
+
+A rule that enforces that function chains always begin with a bare value.
+
 
 ### ComparisonToBoolean
 

--- a/lib/dogma/rule_set/all.ex
+++ b/lib/dogma/rule_set/all.ex
@@ -7,6 +7,7 @@ defmodule Dogma.RuleSet.All do
 
   def list do
     [
+      {BarePipeChainStart},
       {ComparisonToBoolean},
       {DebuggerStatement},
       {FinalNewline},

--- a/lib/dogma/rules/bare_pipe_chain_start.ex
+++ b/lib/dogma/rules/bare_pipe_chain_start.ex
@@ -1,0 +1,76 @@
+defmodule Dogma.Rules.BarePipeChainStart do
+  @moduledoc """
+  A rule that enforces that function chains always begin with a bare value.
+  """
+
+  @behaviour Dogma.Rule
+
+  alias Dogma.Script
+  alias Dogma.Error
+
+  def test(script, _list),
+  do: test(script)
+
+  def test(script) do
+    script
+    |> Script.walk(&check_node/2)
+    |> Enum.reverse
+  end
+
+  defp check_node({:|>, _, [lhs, _]}, errors) do
+    case function_line(lhs) do
+      {:ok, line} -> {node, [error(line) | errors]}
+      _           -> {node, errors}
+    end
+  end
+
+  defp check_node(node, errors) do
+    {node, errors}
+  end
+
+  defp function_line({:|>, _, [lhs, _]}),
+  do: function_line(lhs)
+
+  # exception for map keys
+  defp function_line({{:., _, _}, _, []}),
+  do: nil
+
+  # exception for bare maps
+  defp function_line({:%, _, _}),
+  do: nil
+
+  # exception for structs
+  defp function_line({:%{}, _, _}),
+  do: nil
+
+  # exception for large tuples (size > 2)
+  defp function_line({:{}, _, _}),
+  do: nil
+
+  # exception for module attributes
+  defp function_line({:@, _, _}),
+  do: nil
+
+  defp function_line({atom, meta, args})
+  when is_atom(atom) and is_list(args) do
+    if atom |> to_string |> String.starts_with?("sigil") do
+      nil # exception for sigils
+    else
+      {:ok, meta[:line]}
+    end
+  end
+
+  defp function_line({{:., meta, _}, _, _}),
+  do: {:ok, meta[:line]}
+
+  defp function_line(_),
+  do: nil
+
+  defp error(line) do
+    %Error{
+      rule:    __MODULE__,
+      message: "Function Pipe Chains must start with a bare value",
+      line:    line
+    }
+  end
+end

--- a/lib/dogma/script.ex
+++ b/lib/dogma/script.ex
@@ -92,7 +92,8 @@ defmodule Dogma.Script do
   end
 
   defp lines(source) do
-    Regex.replace( ~r/\n\z/, source, "" )
+    ~r/\n\z/
+    |> Regex.replace(source, "")
     |> String.split("\n")
     |> Enum.with_index
     |> Enum.map(fn {line, i} -> {i + 1, line} end)

--- a/lib/mix/tasks/dogma.ex
+++ b/lib/mix/tasks/dogma.ex
@@ -9,7 +9,8 @@ defmodule Mix.Tasks.Dogma do
   end
 
   defp run_dogma(path) do
-    Dogma.run(path)
+    path
+    |> Dogma.run
     |> any_errors?
     |> if do
       System.halt(666)

--- a/test/dogma/rules/bare_pipe_chain_start_test.exs
+++ b/test/dogma/rules/bare_pipe_chain_start_test.exs
@@ -1,0 +1,241 @@
+defmodule Dogma.Rules.BarePipeChainStartTest do
+  use DogmaTest.Helper
+
+  alias Dogma.Rules.BarePipeChainStart
+  alias Dogma.Script
+  alias Dogma.Error
+
+  def test(script) do
+    script
+    |> Script.parse("foo.ex")
+    |> BarePipeChainStart.test
+  end
+
+  with "a bare start value" do
+    setup context do
+      errors = """
+      42 |> Integer.to_char_list(16) |> IO.puts
+
+      42 |> IO.puts
+
+      "A pie"
+      |> String.upcase
+      |> IO.puts
+
+      foo |> String.downcase |> IO.puts
+
+      :foo
+      |> is_atom
+      |> &(&1)
+      """ |> test
+      %{errors: errors}
+    end
+
+    should_register_no_errors
+  end
+
+  with "namespaced functions" do
+    setup context do
+      errors = """
+      String.strip("nope") |> String.upcase |> String.downcase
+      String.strip("nope") |> String.upcase
+      String.strip("nope")
+      |> String.upcase
+      |> String.downcase
+      |> IO.puts
+      """ |> test
+      %{errors: errors}
+    end
+
+    should_register_errors [
+      %Error{
+        rule: BarePipeChainStart,
+        message: "Function Pipe Chains must start with a bare value",
+        line: 1
+      },
+      %Error{
+        rule: BarePipeChainStart,
+        message: "Function Pipe Chains must start with a bare value",
+        line: 2
+      },
+      %Error{
+        rule: BarePipeChainStart,
+        message: "Function Pipe Chains must start with a bare value",
+        line: 3
+      }
+    ]
+  end
+
+  with "a bare function" do
+    setup context do
+      errors = """
+      tl([1, 2, 3]) |> Enum.map(&(&1 + 1)) |> Enum.join
+      tl([1, 2, 3]) |> Enum.join
+      tl([1, 2, 3])
+      |> Enum.map(&(&1 * &1))
+      |> Enum.join
+      |> IO.puts
+      """ |> test
+      %{errors: errors}
+    end
+
+    should_register_errors [
+      %Error{
+        rule: BarePipeChainStart,
+        message: "Function Pipe Chains must start with a bare value",
+        line: 1
+      },
+      %Error{
+        rule: BarePipeChainStart,
+        message: "Function Pipe Chains must start with a bare value",
+        line: 2
+      },
+      %Error{
+        rule: BarePipeChainStart,
+        message: "Function Pipe Chains must start with a bare value",
+        line: 3
+      }
+    ]
+  end
+
+  with "an anonymous function" do
+    setup context do
+      errors = """
+      add_one.([1, 2, 3]) |> IO.inspect
+      add_one.([1, 2, 3]) |> Enum.join |> IO.puts
+      add_one.([1, 2, 3])
+      |> Enum.join
+      |> IO.puts
+      """ |> test
+
+      %{errors: errors}
+    end
+
+    should_register_errors [
+      %Error{
+        rule: BarePipeChainStart,
+        message: "Function Pipe Chains must start with a bare value",
+        line: 1
+      },
+      %Error{
+        rule: BarePipeChainStart,
+        message: "Function Pipe Chains must start with a bare value",
+        line: 2
+      },
+      %Error{
+        rule: BarePipeChainStart,
+        message: "Function Pipe Chains must start with a bare value",
+        line: 3
+      }
+    ]
+  end
+
+  with "a pattern match do" do
+    setup context do
+      errors = """
+      foo = [1, 2, 3] |> tl |> Enum.join
+      bar = [3, 2, 1]
+      |> tl
+      |> Enum.join
+      """ |> test
+      %{errors: errors}
+    end
+
+    should_register_no_errors
+  end
+
+  with "map values" do
+    setup context do
+      errors = """
+      map.key |> Enum.join
+      map.key |> Enum.map(&String.upcase/1) |> Enum.join
+      map.key
+      |> Enum.map(&String.upcase/1)
+      |> Enum.join
+      """ |> test
+      %{errors: errors}
+    end
+
+    should_register_no_errors
+  end
+
+  with "maps and structs" do
+    setup context do
+      errors = """
+      %Struct{} |> do_thing
+      %Struct{} |> do_thing |> IO.puts
+      %Struct{}
+      |> do_thing
+      |> IO.puts
+      %{} |> do_thing
+      %{} |> do_thing |> IO.puts
+      %{}
+      |> do_thing
+      |> IO.puts
+      """ |> test
+      %{errors: errors}
+    end
+
+    should_register_no_errors
+  end
+
+  with "tuples" do
+    setup context do
+      errors = """
+      {:ok, foo} |> Module.do_thing
+      {:ok, foo} |> Module.do_thing |> do_other
+      {:ok, foo}
+      |> Module.do_thing
+      |> do_other
+      """ |> test
+      %{errors: errors}
+    end
+
+    should_register_no_errors
+  end
+
+  with "large tuples" do
+    setup context do
+      errors = """
+      {:ok, foo, bar} |> Module.do_thing
+      {:ok, foo, bar} |> Module.do_thing |> do_other
+      {:ok, foo, bar}
+      |> Module.do_thing
+      |> do_other
+      """ |> test
+      %{errors: errors}
+    end
+
+    should_register_no_errors
+  end
+
+  with "sigils" do
+    setup context do
+      errors = """
+      ~r/\n\n+\z/ |> Regex.run(string)
+      ~w(foo bar baz)a |> Enum.map(&to_string/1) |> Enum.join
+      ~s(qick brown fox)
+      |> String.upcase
+      |> IO.puts
+      """ |> test
+      %{errors: errors}
+    end
+
+    should_register_no_errors
+  end
+
+  with "module attributes" do
+    setup context do
+      errors = """
+      @attribute |> Enum.join
+      @attribute |> Enum.map(&String.upcase/1) |> Enum.join
+      @attribute
+      |> Enum.map(&String.upcase/1)
+      |> Enum.join
+      """ |> test
+      %{errors: errors}
+    end
+
+    should_register_no_errors
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -9,7 +9,8 @@ defmodule DogmaTest.Helper do
   end
 
   def pending do
-    IO.ANSI.format( [:yellow, "P"] )
+    [:yellow, "P"]
+    |> IO.ANSI.format
     |> IO.write
   end
 end


### PR DESCRIPTION
Here's my shot at a rule for enforcing bare variables at the start of a function chain. Though, I'm honestly not sure if I've caught all possible cases. Though, I certainly got everything in this repo.

I didn't try to get the case where function arguments aren't surrounded by parens, since these don't even parse to a proper AST. Since it would take another pass to catch them, I think they should be in another rule.

Closes #53