### PR TITLE
Add emacs formatter (for Syntastic/Flycheck integration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,50 @@ Inspecting 27 files.
 
 How handy!
 
+### Formatters
+
+You can pass a format to the mix task using the `--format` flag.
+
+```
+> mix dogma --format=flycheck
+
+lib/dogma/rules.ex:23:1: W: Blank lines detected at end of file
+test/dogma/formatter_test.exs:9:1: W: Trailing whitespace detected
+```
+
+#### Simple
+
+This is the default formatter. It displays the progress of the checker
+followed by a summary of violations.
+
+```
+> mix dogma --format=simple
+
+Inspecting 27 files.
+
+.....X..........X..........
+
+27 files, 2 errors!
+
+== lib/dogma/rules.ex ==
+23: TrailingBlankLines: Blank lines detected at end of file
+
+== test/dogma/formatter_test.exs ==
+9: TrailingWhitespace: Trailing whitespace detected [33]
+```
+
+#### Flycheck
+
+A machine-readable format suitable for integration with tools like
+[Flycheck](https://github.com/flycheck/flycheck) or
+[Syntastic](https://github.com/scrooloose/syntastic).
+
+```
+> mix dogma --format=flycheck
+
+lib/dogma/rules.ex:23:1: W: Blank lines detected at end of file
+test/dogma/formatter_test.exs:9:1: W: Trailing whitespace detected
+```
 
 ## Contributor Information
 

--- a/lib/dogma.ex
+++ b/lib/dogma.ex
@@ -10,13 +10,12 @@ defmodule Dogma do
   alias Dogma.Rules
   alias Dogma.ScriptSources
 
-  def run(dir_path \\ "") do
-    dir_path
+  def run({dir, formatter}) do
+    dir
     |> ScriptSources.find
     |> ScriptSources.to_scripts
-    |> Formatter.start
-    |> Rules.test
-    |> Formatter.finish
+    |> Formatter.start(formatter)
+    |> Rules.test(formatter)
+    |> Formatter.finish(formatter)
   end
-
 end

--- a/lib/dogma/formatter/flycheck.ex
+++ b/lib/dogma/formatter/flycheck.ex
@@ -1,0 +1,48 @@
+defmodule Dogma.Formatter.Flycheck do
+  @moduledoc """
+  A formatter that lists information for files with errors.
+
+      /project/lib/test.ex:1:1: W: Modulewith out a @moduledoc detected
+      /project/lib/test.ex:14:1: W: Comparison to a boolean is pointless
+  """
+
+  @behaviour Dogma.Formatter
+
+  alias Dogma.Script
+
+  @doc """
+  Runs at the start of the test suite, displaying nothing
+  """
+  def start(_scripts), do: ""
+
+  @doc """
+  Runs after each script is tested. Prints nothing.
+  """
+  def script(_script), do: ""
+
+  @doc """
+  Runs at the end of the test suite, displaying errors.
+  """
+  def finish(scripts) do
+    errors = scripts
+    |> format_errors
+    |> Enum.join("\n")
+
+    errors <> "\n"
+  end
+
+  defp format_errors(script = %Script{}) do
+    script.errors
+    |> Enum.map(&(format_error(&1, script.path)))
+  end
+
+  defp format_errors(scripts) do
+    scripts
+    |> Enum.map(&format_errors/1)
+    |> List.flatten
+  end
+
+  defp format_error(error, script) do
+    "#{script}:#{error.line}:1: W: #{error.message}"
+  end
+end

--- a/lib/dogma/rules.ex
+++ b/lib/dogma/rules.ex
@@ -12,8 +12,7 @@ defmodule Dogma.Rules do
   @doc """
   Runs the rules in the current rule set on the given scripts.
   """
-  def test(scripts) do
-    formatter = Formatter.default_formatter
+  def test(scripts, formatter) do
     test_set = selected_set
     scripts
       |> Enum.map(&Task.async(fn -> test_script(&1, formatter, test_set) end))

--- a/lib/mix/tasks/dogma.ex
+++ b/lib/mix/tasks/dogma.ex
@@ -4,17 +4,31 @@ defmodule Mix.Tasks.Dogma do
   @shortdoc  "Check Elixir source files for style violations"
   @moduledoc @shortdoc
 
-  def run(argv) do
-    argv |> List.first |> run_dogma
-  end
+  alias Dogma.Formatter
 
-  defp run_dogma(path) do
-    path
+  @formatters %{
+    "simple" => Formatter.Simple,
+    "flycheck"  => Formatter.Flycheck
+  }
+
+  def run(argv) do
+    argv
+    |> parse_args
     |> Dogma.run
     |> any_errors?
     |> if do
       System.halt(666)
     end
+  end
+
+  def parse_args(argv) do
+    switches = [format: :string]
+    {switches, files, []} = OptionParser.parse(argv, switches: switches)
+
+    format = Keyword.get(switches, :format)
+    formatter = Map.get(@formatters, format, Formatter.default_formatter)
+
+    {List.first(files), formatter}
   end
 
   defp any_errors?(scripts) do

--- a/test/dogma/formatter/flycheck_test.exs
+++ b/test/dogma/formatter/flycheck_test.exs
@@ -1,0 +1,74 @@
+defmodule Dogma.Formatter.FlycheckTest do
+  use ShouldI
+
+  alias Dogma.Formatter.Flycheck
+  alias Dogma.Script
+  alias Dogma.Error
+
+  with ".start" do
+    with "no files to list" do
+      should "print nothing" do
+        assert Flycheck.start([]) == ""
+      end
+    end
+
+    with "some files to lint" do
+      should "print nothing" do
+        script = [%Script{}, %Script{}, %Script{}]
+        assert Flycheck.start(script) == ""
+      end
+    end
+  end
+
+  with ".script" do
+    with "no errors" do
+      should "print nothing" do
+        script = %Script{ errors: [] }
+        assert Flycheck.script(script) == ""
+      end
+    end
+
+    with "some errors" do
+      should "print nothing" do
+        script = %Script{ errors: [%Error{}] }
+        assert Flycheck.script(script) == ""
+      end
+    end
+  end
+
+  with ".finish" do
+    with "no errors" do
+      should "print a new line" do
+        script = [%Script{ errors: [] }]
+        assert Flycheck.finish(script) == "\n"
+      end
+    end
+
+    with "some errors" do
+      should "print each error" do
+        error1 = %Error{
+          line: 1,
+          message: "Module without a @moduledoc detected"
+        }
+        error2 = %Error{
+          line: 14,
+          message: "Comparison to a boolean is pointless"
+        }
+
+        script = [
+          %Script{ path: "foo.ex", errors: [error1] },
+          %Script{ path: "bar.ex", errors: [error1, error2] },
+          %Script{ path: "baz.ex", errors: [] }
+        ]
+
+        expected = """
+        foo.ex:1:1: W: Module without a @moduledoc detected
+        bar.ex:1:1: W: Module without a @moduledoc detected
+        bar.ex:14:1: W: Comparison to a boolean is pointless
+        """
+
+        assert Flycheck.finish(script) == expected
+      end
+    end
+  end
+end

--- a/test/mix/tasks/dogma_test.exs
+++ b/test/mix/tasks/dogma_test.exs
@@ -1,0 +1,53 @@
+defmodule Dogma.OptionParserTest do
+  use ShouldI
+
+  @default_formatter Dogma.Formatter.default_formatter
+
+  defp parse_args(args) do
+    Mix.Tasks.Dogma.parse_args(args)
+  end
+
+  with ".parse_args" do
+    with "empty args" do
+      should "return nil and default formatter" do
+        assert parse_args([]) == {nil, @default_formatter}
+      end
+    end
+
+    with "directories given" do
+      should "return directory and default formatter" do
+        assert parse_args(["lib/foo"]) == {"lib/foo", @default_formatter}
+      end
+
+      with "multiple directories given" do
+        should "return first directory only" do
+          parsed = parse_args(["lib/foo", "lib/bar"])
+          assert parsed == {"lib/foo", @default_formatter}
+        end
+      end
+    end
+
+    with "format option passed" do
+      with "simple passed" do
+        should "return simple formatter" do
+          parsed = parse_args(["--format", "simple"])
+          assert parsed == {nil, Dogma.Formatter.Simple}
+        end
+      end
+
+      with "flycheck passed" do
+        should "return flycheck formatter" do
+          parsed = parse_args(["--format=flycheck"])
+          assert parsed == {nil, Dogma.Formatter.Flycheck}
+        end
+      end
+
+      with "unknown formatter passed" do
+        should "return default formatter" do
+          parsed = parse_args(["--format", "false"])
+          assert parsed == {nil, @default_formatter}
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Here's my shot at a Syntastic/Flycheck format. The Syntastic checker for Rubocop uses the emacs format. Both Syntastic and Flycheck require a custom checker to be built for each tool, but this format seems to be the standard output used.

I've added tests for option parsing, but I'm not sure how you want to handle integration tests.

Closes #8 