### PR TITLE
Add rule disallowing semicolons

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,7 +1,7 @@
 # Dogma Rules
 
 These are the rules included in Dogma by default. Currently there are
-19 of them.
+20 of them.
 
 ## Contents
 
@@ -19,6 +19,7 @@ These are the rules included in Dogma by default. Currently there are
 * [NegatedIfUnless](https://github.com/lpil/dogma/blob/master/docs/rules.md#negatedifunless)
 * [PredicateName](https://github.com/lpil/dogma/blob/master/docs/rules.md#predicatename)
 * [QuotesInString](https://github.com/lpil/dogma/blob/master/docs/rules.md#quotesinstring)
+* [Semicolon](https://github.com/lpil/dogma/blob/master/docs/rules.md#semicolon)
 * [TrailingBlankLines](https://github.com/lpil/dogma/blob/master/docs/rules.md#trailingblanklines)
 * [TrailingWhitespace](https://github.com/lpil/dogma/blob/master/docs/rules.md#trailingwhitespace)
 * [UnlessElse](https://github.com/lpil/dogma/blob/master/docs/rules.md#unlesselse)
@@ -214,6 +215,19 @@ Use s_sigil or S_sigil instead or string literals in these situation.
 
     # Good
     ~s(")
+
+
+### Semicolon
+
+A rule that disallows semicolons to terminate or separate statements.
+
+For example, these are considered invalid:
+
+   foo = "bar";
+   bar = "baz"; fizz = :buzz
+
+This is because Elixir does not require semicolons to terminate expressions,
+and breaking up multiple expressions on different lines improves readability.
 
 
 ### TrailingBlankLines

--- a/lib/dogma/rule_set/all.ex
+++ b/lib/dogma/rule_set/all.ex
@@ -21,6 +21,7 @@ defmodule Dogma.RuleSet.All do
       {NegatedIfUnless},
       {PredicateName},
       {QuotesInString},
+      {Semicolon},
       {TrailingBlankLines},
       {TrailingWhitespace},
       {UnlessElse},

--- a/lib/dogma/rules/semicolon.ex
+++ b/lib/dogma/rules/semicolon.ex
@@ -1,0 +1,60 @@
+defmodule Dogma.Rules.Semicolon do
+  @moduledoc """
+  A rule that disallows semicolons to terminate or separate statements.
+
+  For example, these are considered invalid:
+
+     foo = "bar";
+     bar = "baz"; fizz = :buzz
+
+  This is because Elixir does not require semicolons to terminate expressions,
+  and breaking up multiple expressions on different lines improves readability.
+  """
+
+  @behaviour Dogma.Rule
+
+  alias Dogma.Error
+
+  def test(script, _config \\ []) do
+    {:ok, _, tokens} =
+      script.source
+      |> String.to_char_list
+      |> :elixir_tokenizer.tokenize(1, [])
+
+    tokens
+    |> get_semicolon_lines
+    |> Enum.map(&to_error/1)
+  end
+
+  defp get_semicolon_lines(tree, acc \\ [])
+
+  defp get_semicolon_lines([], acc) do
+    Enum.reverse(acc)
+  end
+
+  defp get_semicolon_lines([{:';', line} | rest], acc) do
+    get_semicolon_lines(rest, [line | acc])
+  end
+
+  defp get_semicolon_lines([{_, _, children} | rest], acc)
+  when is_list(children) do
+    get_semicolon_lines(children ++ rest, acc)
+  end
+
+  defp get_semicolon_lines([{_, children} | rest], acc)
+  when is_list(children) do
+    get_semicolon_lines(children ++ rest, acc)
+  end
+
+  defp get_semicolon_lines([_ | rest], acc) do
+    get_semicolon_lines(rest, acc)
+  end
+
+  defp to_error(line) do
+    %Error{
+      rule: __MODULE__,
+      message: "Expressions should not be terminated by semicolons.",
+      line: line
+    }
+  end
+end

--- a/test/dogma/rules/semicolon_test.exs
+++ b/test/dogma/rules/semicolon_test.exs
@@ -1,0 +1,117 @@
+defmodule Dogma.Rules.SemicolonTest do
+  use ShouldI
+
+  @message "Expressions should not be terminated by semicolons."
+
+  alias Dogma.Rules.Semicolon
+  alias Dogma.Script
+  alias Dogma.Error
+
+  defp apply_rule(script) do
+    script
+    |> Script.parse!("foo.ex")
+    |> Semicolon.test
+  end
+
+  should "error when expression is terminated with semicolon" do
+    errors = """
+    x = 1;
+    y = 1;
+    """ |> apply_rule
+
+    assert errors == [
+      %Error{
+        rule: Semicolon,
+        message: @message,
+        line: 1
+      },
+      %Error{
+        rule: Semicolon,
+        message: @message,
+        line: 2
+      }
+    ]
+  end
+
+  should "error when expression is separated by semicolon" do
+    errors = """
+    x = 1; y = 1
+    """ |> apply_rule
+
+    assert errors == [
+      %Error{
+        rule: Semicolon,
+        message: @message,
+        line: 1
+      }
+    ]
+  end
+
+  should "return multiple errors per line if there are multiple semicolons" do
+    errors = """
+    x = 1; y = 1;
+    """ |> apply_rule
+
+    assert errors == [
+      %Error{
+        rule: Semicolon,
+        message: @message,
+        line: 1
+      },
+      %Error{
+        rule: Semicolon,
+        message: @message,
+        line: 1
+      }
+    ]
+  end
+
+  should "not return any errors when semicolons are in comments" do
+    errors = """
+    # Using a semicolon isn't hard; I once saw a party gorilla do it.
+    """ |> apply_rule
+
+    assert errors == []
+  end
+
+  should "not return any errors when semicolons are in strings" do
+    errors = """
+    "Using a semicolon isn't hard; I once saw a party gorilla do it."
+    'Using a semicolon isn\\'t hard; I once saw a party gorilla do it.'
+    ~S(Using a semicolon isn't hard; I once saw a party gorilla do it.)
+    ~s(Using a semicolon isn't hard; I once saw a party gorilla do it.)
+    """ |> apply_rule
+
+    assert errors == []
+  end
+
+  should "return an error when semicolon is in string interpolation" do
+    errors = """
+    "Foo bar, #\{x = 3; inspect(x)} more string stuff"
+    """ |> apply_rule
+
+    assert errors == [
+      %Error{
+        rule: Semicolon,
+        message: @message,
+        line: 1
+      }
+    ]
+  end
+
+  should "return an error when a semicolon is in a nested context" do
+    errors = """
+    if (x = 3; x == 3) do
+      true
+    end
+    """ |> apply_rule
+
+    assert errors == [
+      %Error{
+        rule: Semicolon,
+        message: @message,
+        line: 1
+      }
+    ]
+  end
+end


### PR DESCRIPTION
I'm pulling in the Elixir tokenizer for this one and I know there's a spike for that #64. Do you want me to pull that into the `Dogma.Script` module? Maybe add a `Dogma.Script.tokens` field?

Closes #47 