### PR TITLE
Add current value to error messages

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -200,7 +200,8 @@ So the following would be invalid:
 
 ### LineLength
 
-A rule that disallows lines longer than 80 characters in length.
+A rule that disallows lines longer than X characters in length (defaults to
+80).
 
 This rule can be configured with the `max_length` option, which allows you to
 specify your own line max character count.

--- a/lib/dogma/rules/function_arity.ex
+++ b/lib/dogma/rules/function_arity.ex
@@ -38,7 +38,7 @@ defmodule Dogma.Rules.FunctionArity do
       {name, line, args} = get_fun_details(node)
       arity = args |> length
       if arity > max do
-        {node, [error(line, name, max) | errors]}
+        {node, [error(line, name, max, arity) | errors]}
       else
         {node, errors}
       end
@@ -57,10 +57,10 @@ defmodule Dogma.Rules.FunctionArity do
     {name, line, args}
   end
 
-  defp error(line_number, name, max) do
+  defp error(line_number, name, max, arity) do
     %Error{
       rule:    __MODULE__,
-      message: "Arity of `#{name}` should be less than #{max}",
+      message: "Arity of `#{name}` should be less than #{max} (was #{arity}).",
       line: line_number,
     }
   end

--- a/lib/dogma/rules/line_length.ex
+++ b/lib/dogma/rules/line_length.ex
@@ -1,6 +1,7 @@
 defmodule Dogma.Rules.LineLength do
   @moduledoc """
-  A rule that disallows lines longer than 80 characters in length.
+  A rule that disallows lines longer than X characters in length (defaults to
+  80).
 
   This rule can be configured with the `max_length` option, which allows you to
   specify your own line max character count.
@@ -19,7 +20,7 @@ defmodule Dogma.Rules.LineLength do
   def test(script, max_length: max) do
     script.lines
     |> Enum.filter(&longer_than(&1, max))
-    |> Enum.map(&error/1)
+    |> Enum.map(&error(&1, max))
   end
 
 
@@ -27,10 +28,11 @@ defmodule Dogma.Rules.LineLength do
     String.length(line) > max
   end
 
-  defp error({line_num, _}) do
+  defp error({line_num, line}, max) do
+    len = String.length(line)
     %Error{
       rule:     __MODULE__,
-      message:  "Line too long",
+      message:  "Line length should not exceed #{max} chars (was #{len}).",
       line: line_num,
     }
   end

--- a/test/dogma/rules/function_arity_test.exs
+++ b/test/dogma/rules/function_arity_test.exs
@@ -48,12 +48,12 @@ defmodule Dogma.Rules.FunctionArityTest do
     expected_errors = [
       %Error{
         rule:    FunctionArity,
-        message: "Arity of `volume` should be less than 4",
+        message: "Arity of `volume` should be less than 4 (was 5).",
         line: 3,
       },
       %Error{
         rule:    FunctionArity,
-        message: "Arity of `point` should be less than 4",
+        message: "Arity of `point` should be less than 4 (was 5).",
         line: 1,
       },
     ]
@@ -72,7 +72,7 @@ defmodule Dogma.Rules.FunctionArityTest do
     expected_errors = [
       %Error{
         rule:     FunctionArity,
-        message:  "Arity of `radius` should be less than 2",
+        message:  "Arity of `radius` should be less than 2 (was 3).",
         line: 3,
       }
     ]

--- a/test/dogma/rules/line_length_test.exs
+++ b/test/dogma/rules/line_length_test.exs
@@ -14,12 +14,12 @@ defmodule Dogma.Rules.LineLengthTest do
     expected_errors = [
       %Error{
         rule: LineLength,
-        message: "Line too long",
+        message: "Line length should not exceed 80 chars (was 90).",
         line: 1,
       },
       %Error{
         rule: LineLength,
-        message: "Line too long",
+        message: "Line length should not exceed 80 chars (was 101).",
         line: 3,
       },
     ]
@@ -38,7 +38,7 @@ defmodule Dogma.Rules.LineLengthTest do
     expected_errors = [
       %Error{
         rule: LineLength,
-        message: "Line too long",
+        message: "Line length should not exceed 100 chars (was 101).",
         line: 3,
       },
     ]


### PR DESCRIPTION
This adds the current value (which is violating some rule) to error message for `LineLength` and `FunctionArity`.

This seems like a great project! :+1: