### PR TITLE
mix.exs: add lib/dogma.ex

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,6 +35,7 @@ defmodule Dogma.Mixfile do
     ~w(
       LICENCE
       README.md
+      lib/dogma.ex
       lib/dogma
       lib/mix/tasks/dogma.ex
       mix.exs


### PR DESCRIPTION
Getting errors due to this missing.

```
$ mix deps.get
…
$ mix dogma
…
** (UndefinedFunctionError) undefined function: Dogma.run/1 (module Dogma is not available)
    Dogma.run({nil, Dogma.Formatter.Simple})
    lib/mix/tasks/dogma.ex:12: Mix.Tasks.Dogma.run/1
    (mix) lib/mix/cli.ex:55: Mix.CLI.run_task/2
    (elixir) lib/code.ex:307: Code.require_file/2
```