### PR TITLE
Fix violations

### DIFF
--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -54,11 +54,13 @@ The JSON structure is like the following example:
           "errors": [{
               "line": 1,
               "rule": "ModuleDoc",
-              "message": "Module without @moduledoc detected"
+              "message": "Module without @moduledoc detected",
+              "fixed": false
            }, {
               "line": 14,
               "rule": "ComparisonToBoolean",
-              "message": "Comparison to a boolean is useless"
+              "message": "Comparison to a boolean is useless",
+              "fixed": true
            }
           ]
       }],

--- a/lib/dogma.ex
+++ b/lib/dogma.ex
@@ -11,14 +11,14 @@ defmodule Dogma do
   alias Dogma.ScriptSources
   alias Dogma.Corrections
 
-  def run({dir, %{formatter: formatter, fix: fix}}) do
+  def run({dir, %{formatter: formatter, fix?: fix?} = opts}) do
     dir
     |> ScriptSources.find(exclude_patterns)
     |> ScriptSources.to_scripts
     |> Formatter.start(formatter)
     |> Rules.test(formatter)
-    |> Corrections.repair(fix)
-    |> Formatter.finish(formatter)
+    |> Corrections.repair(fix?)
+    |> Formatter.finish(opts)
   end
 
   defp exclude_patterns do

--- a/lib/dogma.ex
+++ b/lib/dogma.ex
@@ -10,7 +10,7 @@ defmodule Dogma do
   alias Dogma.Rules
   alias Dogma.ScriptSources
 
-  def run({dir, formatter}) do
+  def run({dir, %{formatter: formatter, fix: fix}}) do
     dir
     |> ScriptSources.find(exclude_patterns)
     |> ScriptSources.to_scripts

--- a/lib/dogma.ex
+++ b/lib/dogma.ex
@@ -9,6 +9,7 @@ defmodule Dogma do
   alias Dogma.Formatter
   alias Dogma.Rules
   alias Dogma.ScriptSources
+  alias Dogma.Corrections
 
   def run({dir, %{formatter: formatter, fix: fix}}) do
     dir
@@ -16,6 +17,7 @@ defmodule Dogma do
     |> ScriptSources.to_scripts
     |> Formatter.start(formatter)
     |> Rules.test(formatter)
+    |> Corrections.repair(fix)
     |> Formatter.finish(formatter)
   end
 

--- a/lib/dogma/corrections.ex
+++ b/lib/dogma/corrections.ex
@@ -1,0 +1,18 @@
+defmodule Dogma.Corrections do
+  @moduledoc """
+  Responsible for running of the appropriate correction set on a given set
+  of scripts with the appropriate configuration.
+  """
+
+  alias Dogma.Script
+
+  @doc """
+  Runs Script.repair asynchronously.  
+  """
+  def repair(scripts, false), do: scripts
+  def repair(scripts, true) do
+    scripts
+      |> Enum.map(&Task.async(fn -> &1 |> Script.repair end))
+      |> Enum.map(&Task.await/1)
+  end
+end

--- a/lib/dogma/error.ex
+++ b/lib/dogma/error.ex
@@ -6,5 +6,6 @@ defmodule Dogma.Error do
 
   defstruct rule:    nil,
             message: nil,
-            line:    nil
+            line:    nil,
+            fixed?:  false
 end

--- a/lib/dogma/formatter.ex
+++ b/lib/dogma/formatter.ex
@@ -45,8 +45,8 @@ defmodule Dogma.Formatter do
   @doc """
   Runs at the end of the test suite.
   """
-  def finish(files, formatter \\ @default_formatter) do
-    IO.write formatter.finish( files )
+  def finish(files, %{formatter: formatter, fix?: fix?}) do
+    IO.write formatter.finish( files, fix? )
     files
   end
 

--- a/lib/dogma/formatter/flycheck.ex
+++ b/lib/dogma/formatter/flycheck.ex
@@ -35,6 +35,7 @@ defmodule Dogma.Formatter.Flycheck do
 
   defp format_errors(script = %Script{}) do
     script.errors
+    |> Enum.filter(fn err -> !err.fixed? end)
     |> Enum.map(&(format_error(&1, script.path)))
   end
 

--- a/lib/dogma/formatter/json.ex
+++ b/lib/dogma/formatter/json.ex
@@ -19,11 +19,13 @@ defmodule Dogma.Formatter.JSON do
             "errors": [{
                 "line": 1,
                 "rule": "ModuleDoc",
-                "message": "Module without @moduledoc detected"
+                "message": "Module without @moduledoc detected",
+                "fixed": false
              }, {
                 "line": 14,
                 "rule": "ComparisonToBoolean",
-                "message": "Comparison to a boolean is useless"
+                "message": "Comparison to a boolean is useless",
+                "fixed": true
              }
             ]
         }],
@@ -85,7 +87,8 @@ defmodule Dogma.Formatter.JSON do
     %{
       line: error.line,
       rule: printable_name(error.rule),
-      message: error.message
+      message: error.message,
+      fixed: error.fixed?
     }
   end
 

--- a/lib/dogma/rule.ex
+++ b/lib/dogma/rule.ex
@@ -1,6 +1,8 @@
 defmodule Dogma.Rule do
   @moduledoc """
   The Rule behaviour, used to assert the interface used by our Rule modules.
+  A rule can also define an optional correction callback which takes
+  a source string and a list of violations.
   """
 
   alias Dogma.Script

--- a/lib/dogma/rules/trailing_whitespace.ex
+++ b/lib/dogma/rules/trailing_whitespace.ex
@@ -13,6 +13,13 @@ defmodule Dogma.Rules.TrailingWhitespace do
     Enum.reduce( script.processed_lines, [], &check_line(&1, &2) )
   end
 
+  def correction(script, error) do
+    script.source
+    |> String.split("\n")
+    |> Enum.map(&String.rstrip/1)
+    |> Enum.join("\n")
+  end
+
   defp check_line({i, line}, errors) do
     trimmed_line = String.replace(line, ~r/\r\z/, "")
     case Regex.run( @regex, trimmed_line, return: :index ) do

--- a/lib/dogma/rules/trailing_whitespace.ex
+++ b/lib/dogma/rules/trailing_whitespace.ex
@@ -13,11 +13,21 @@ defmodule Dogma.Rules.TrailingWhitespace do
     Enum.reduce( script.processed_lines, [], &check_line(&1, &2) )
   end
 
-  def correction(script, error) do
-    script.source
-    |> String.split("\n")
-    |> Enum.map(&String.rstrip/1)
-    |> Enum.join("\n")
+  def correction(source, errors) do
+    lines = Enum.map(errors, fn err -> err.line end)
+    [newline] = Regex.run(~r/\r?\n\z/, source)
+
+    source
+    |> String.split(newline)
+    |> Enum.with_index
+    |> Enum.map(fn {line, i} ->
+      if Enum.member?(lines, i + 1) do
+        String.replace(line, @regex, "")
+      else
+        line
+      end
+    end)
+    |> Enum.join(newline)
   end
 
   defp check_line({i, line}, errors) do

--- a/lib/dogma/script.ex
+++ b/lib/dogma/script.ex
@@ -121,9 +121,8 @@ defmodule Dogma.Script do
 
   @doc """
   Builds the corrected_source by running the corrections
-  for any rule that has implemented one and which has
-  not been turned off by configuration. Then replaces the file at
-  at the path with the corrected source.
+  for any rule that has implemented correction/2. Then replaces the file at
+  at the path with the corrected source. The correction is run once for each rule.
   """
   def repair(script, io \\ File) do
     script.errors

--- a/lib/mix/tasks/dogma.ex
+++ b/lib/mix/tasks/dogma.ex
@@ -24,9 +24,9 @@ defmodule Mix.Tasks.Dogma do
     formatter = Map.get(Formatter.formatters,
                         format,
                         Formatter.default_formatter)
-    fix = Keyword.get(switches, :fix, false)
+    fix? = Keyword.get(switches, :fix, false)
 
-    {List.first(files), %{formatter: formatter, fix: fix}}
+    {List.first(files), %{formatter: formatter, fix?: fix?}}
   end
 
   defp any_errors?(scripts) do

--- a/lib/mix/tasks/dogma.ex
+++ b/lib/mix/tasks/dogma.ex
@@ -17,15 +17,16 @@ defmodule Mix.Tasks.Dogma do
   end
 
   def parse_args(argv) do
-    switches = [format: :string]
+    switches = [format: :string, fix: :boolean]
     {switches, files, []} = OptionParser.parse(argv, switches: switches)
 
     format = Keyword.get(switches, :format)
     formatter = Map.get(Formatter.formatters,
                         format,
                         Formatter.default_formatter)
+    fix = Keyword.get(switches, :fix, false)
 
-    {List.first(files), formatter}
+    {List.first(files), %{formatter: formatter, fix: fix}}
   end
 
   defp any_errors?(scripts) do

--- a/test/dogma/formatter/flycheck_test.exs
+++ b/test/dogma/formatter/flycheck_test.exs
@@ -69,6 +69,36 @@ defmodule Dogma.Formatter.FlycheckTest do
 
         assert Flycheck.finish(script) == expected
       end
+
+      should "ignore fixed errors" do
+        error1 = %Error{
+          line: 1,
+          message: "Module without a @moduledoc detected"
+        }
+        error2 = %Error{
+          line: 14,
+          message: "Comparison to a boolean is pointless"
+        }
+        error3 = %Error{
+          line: 15,
+          message: "Trailing whitespace detected",
+          fixed?: true
+        }
+
+        script = [
+          %Script{ path: "foo.ex", errors: [error1, error3] },
+          %Script{ path: "bar.ex", errors: [error1, error2, error3] },
+          %Script{ path: "baz.ex", errors: [error3] }
+        ]
+
+        expected = """
+        foo.ex:1:1: W: Module without a @moduledoc detected
+        bar.ex:1:1: W: Module without a @moduledoc detected
+        bar.ex:14:1: W: Comparison to a boolean is pointless
+        """
+
+        assert Flycheck.finish(script) == expected
+      end
     end
   end
 end

--- a/test/dogma/formatter/json_test.exs
+++ b/test/dogma/formatter/json_test.exs
@@ -66,12 +66,14 @@ defmodule Dogma.Formatter.JSONTest do
           %Error{
             line: 1,
             rule: Dogma.Rules.ModuleDoc,
-            message: "Module without a @moduledoc detected"
+            message: "Module without a @moduledoc detected",
+            fixed?: true
           },
           %Error{
             line: 14,
             rule: Dogma.Rules.ComparisonToBoolean,
-            message: "Comparison to a boolean is pointless"
+            message: "Comparison to a boolean is pointless",
+            fixed?: false
           }
         ]
 
@@ -90,12 +92,14 @@ defmodule Dogma.Formatter.JSONTest do
               %{
                 "line" => 1,
                 "rule" => "ModuleDoc",
-                "message" => "Module without a @moduledoc detected"
+                "message" => "Module without a @moduledoc detected",
+                "fixed" => true
               },
               %{
                 "line" => 14,
                 "rule" => "ComparisonToBoolean",
-                "message" => "Comparison to a boolean is pointless"
+                "message" => "Comparison to a boolean is pointless",
+                "fixed" => false
               }
             ]}
         ]

--- a/test/dogma/formatter_test.exs
+++ b/test/dogma/formatter_test.exs
@@ -8,7 +8,7 @@ defmodule Dogma.FormatterTest do
   defmodule TestFormatter do
     def start(_)  do "start"  end
     def script(_) do "script" end
-    def finish(_) do "finish" end
+    def finish(_, _) do "finish" end
   end
 
   with ".start" do
@@ -30,7 +30,7 @@ defmodule Dogma.FormatterTest do
   with ".finish" do
     should "print with the formatter" do
       assert "finish" == capture_io(fn ->
-        Formatter.finish( [], TestFormatter )
+        Formatter.finish( [], %{formatter: TestFormatter, fix?: false})
       end)
     end
   end

--- a/test/dogma/rules/trailing_whitespace_test.exs
+++ b/test/dogma/rules/trailing_whitespace_test.exs
@@ -46,4 +46,73 @@ defmodule Dogma.Rules.TrailingWhitespaceTest do
     errors = source |> test
     assert [] == errors
   end
+
+  with "correction/2" do
+    should "strip trailing whitespace" do
+      source = "   'hello'\n"
+          <> "'how'       \n"
+          <> "  'are'\n"
+          <> "      'you?'  \n"
+
+      corrected = "   'hello'\n"
+          <> "'how'\n"
+          <> "  'are'\n"
+          <> "      'you?'\n"
+
+      errors = [
+        %Error{
+          rule: TrailingWhitespace,
+          message: "Trailing whitespace detected",
+          line: 4,
+        },
+        %Error{
+          rule: TrailingWhitespace,
+          message: "Trailing whitespace detected",
+          line: 2,
+        },
+      ]
+
+      assert TrailingWhitespace.correction(source, errors) == corrected
+    end
+
+    should "does not change windows style line terminations" do
+      source = "   'hello'\r\n"
+          <> "'how'\r\n"
+          <> "  'are'\r\n"
+          <> "      'you?'   \r\n"
+
+      corrected = "   'hello'\r\n"
+          <> "'how'\r\n"
+          <> "  'are'\r\n"
+          <> "      'you?'\r\n"
+
+      error =
+        %Error{
+          rule: TrailingWhitespace,
+          message: "Trailing whitespace detected",
+          line: 4,
+        }
+      assert TrailingWhitespace.correction(source, [error]) == corrected
+    end
+
+    should "not correct trailing whitespace in triple quote strings" do
+      source = ~s("""\n)
+            <> ~s(1 + 1       \n)
+            <> ~s("""\n)
+            <> "'code'   \n"
+
+      corrected = ~s("""\n)
+            <> ~s(1 + 1       \n)
+            <> ~s("""\n)
+            <> "'code'\n"
+
+      error =
+        %Error{
+          rule: TrailingWhitespace,
+          message: "Trailing whitespace detected",
+          line: 4,
+        }
+      assert TrailingWhitespace.correction(source, [error]) == corrected
+    end
+  end
 end

--- a/test/mix/tasks/dogma_test.exs
+++ b/test/mix/tasks/dogma_test.exs
@@ -9,20 +9,24 @@ defmodule Dogma.OptionParserTest do
 
   with ".parse_args" do
     with "empty args" do
-      should "return nil and default formatter" do
-        assert parse_args([]) == {nil, @default_formatter}
+      should "return nil and default formatter and fix set to false" do
+        {dir, options} = parse_args([])
+        assert dir == nil
+        assert options == %{fix: false, formatter: @default_formatter}
       end
     end
 
     with "directories given" do
-      should "return directory and default formatter" do
-        assert parse_args(["lib/foo"]) == {"lib/foo", @default_formatter}
+      should "return directory and default formatter and fix set to false" do
+        {path, options} = parse_args(["lib/foo"])
+        assert path == "lib/foo"
+        assert match?( %{fix: false, formatter: @default_formatter}, options)
       end
 
       with "multiple directories given" do
         should "return first directory only" do
-          parsed = parse_args(["lib/foo", "lib/bar"])
-          assert parsed == {"lib/foo", @default_formatter}
+          {dir, _}  = parse_args(["lib/foo", "lib/bar"])
+          assert dir == "lib/foo"
         end
       end
     end
@@ -30,23 +34,30 @@ defmodule Dogma.OptionParserTest do
     with "format option passed" do
       with "simple passed" do
         should "return simple formatter" do
-          parsed = parse_args(["--format", "simple"])
-          assert parsed == {nil, Dogma.Formatter.Simple}
+          {_, options} = parse_args(["--format", "simple"])
+          assert match?( %{formatter: Dogma.Formatter.Simple}, options )
         end
       end
 
       with "flycheck passed" do
         should "return flycheck formatter" do
-          parsed = parse_args(["--format=flycheck"])
-          assert parsed == {nil, Dogma.Formatter.Flycheck}
+          {_, options} = parse_args(["--format=flycheck"])
+          assert match?( %{formatter: Dogma.Formatter.Flycheck}, options )
         end
       end
 
       with "unknown formatter passed" do
         should "return default formatter" do
-          parsed = parse_args(["--format", "false"])
-          assert parsed == {nil, @default_formatter}
+          {_, options} = parse_args(["--format", "false"])
+          assert match?( %{formatter: @default_formatter}, options )
         end
+      end
+    end
+
+    with "--fix passed" do
+      should "add fix: true to the options" do
+        {_, options} = parse_args(["--fix"])
+        assert match?( %{fix: true}, options )
       end
     end
   end

--- a/test/mix/tasks/dogma_test.exs
+++ b/test/mix/tasks/dogma_test.exs
@@ -12,7 +12,7 @@ defmodule Dogma.OptionParserTest do
       should "return nil and default formatter and fix set to false" do
         {dir, options} = parse_args([])
         assert dir == nil
-        assert options == %{fix: false, formatter: @default_formatter}
+        assert options == %{fix?: false, formatter: @default_formatter}
       end
     end
 
@@ -20,7 +20,7 @@ defmodule Dogma.OptionParserTest do
       should "return directory and default formatter and fix set to false" do
         {path, options} = parse_args(["lib/foo"])
         assert path == "lib/foo"
-        assert match?( %{fix: false, formatter: @default_formatter}, options)
+        assert match?( %{fix?: false, formatter: @default_formatter}, options)
       end
 
       with "multiple directories given" do
@@ -57,7 +57,7 @@ defmodule Dogma.OptionParserTest do
     with "--fix passed" do
       should "add fix: true to the options" do
         {_, options} = parse_args(["--fix"])
-        assert match?( %{fix: true}, options )
+        assert match?( %{fix?: true}, options )
       end
     end
   end


### PR DESCRIPTION
Thought I'd take a crack at https://github.com/lpil/dogma/issues/25

Allows a user to pass --fix to the mix task and trailing whitespace errors will get fixed.
Other rules can do the same by implementing a correction callback.
Couple things I could use guidance on:
- Is there a way to officially define an optional callback as part of a behaviour? 
- Is this how we want to handle formatting for fixes?
- Obviously this whole approach could be bad for some reason.
