### PR TITLE
Add failing test for BarePipeChainStart

### DIFF
--- a/test/dogma/rule/bare_pipe_chain_start_test.exs
+++ b/test/dogma/rule/bare_pipe_chain_start_test.exs
@@ -52,6 +52,15 @@ defmodule Dogma.Rule.BarePipeChainStartTest do
     assert [] == errors
   end
 
+  should "not error with a keyword lookup start" do
+    errors = """
+    map[:foo]
+    |> is_atom
+    |> IO.inspect
+    """ |> lint
+    assert [] == errors
+  end
+
   should "error for non-bare start namespaced functions" do
     errors = """
     String.strip("nope") |> String.upcase |> String.downcase


### PR DESCRIPTION
It should not fail when we start with a simple lookup on a keyword list
or map. Currently this fails:

    map[:foo]
    |> is_atom
    |> IO.inspect

which would have to be written like this to pass:

    map
    |> Keyword.get(:foo)
    |> is_atom
    |> IO.inspect

I was not yet able to fix this, but will try to provide a fix later this week. For now, a failing test should remind us that this rule needs some love :wink: 