### PR TITLE
Add new Rule: ExceptionName

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,13 +1,14 @@
 # Dogma Rules
 
 These are the rules included in Dogma by default. Currently there are
-24 of them.
+25 of them.
 
 ## Contents
 
 * [BarePipeChainStart](https://github.com/lpil/dogma/blob/master/docs/rules.md#barepipechainstart)
 * [ComparisonToBoolean](https://github.com/lpil/dogma/blob/master/docs/rules.md#comparisontoboolean)
 * [DebuggerStatement](https://github.com/lpil/dogma/blob/master/docs/rules.md#debuggerstatement)
+* [ExceptionName](https://github.com/lpil/dogma/blob/master/docs/rules.md#exceptionname)
 * [FinalCondition](https://github.com/lpil/dogma/blob/master/docs/rules.md#finalcondition)
 * [FinalNewline](https://github.com/lpil/dogma/blob/master/docs/rules.md#finalnewline)
 * [FunctionArity](https://github.com/lpil/dogma/blob/master/docs/rules.md#functionarity)
@@ -77,6 +78,27 @@ A rule that disallows calls to `IEx.pry`.
 
 This is because we don't want debugger breakpoints accidentally being
 committed into our codebase.
+
+
+### ExceptionName
+
+A Rule that checks that exception names end with a trailing Error.
+
+For example, prefer this:
+
+    defmodule BadHTTPCodeError do
+      defexception [:message]
+    end
+
+Not one of these:
+
+    defmodule BadHTTPCode do
+      defexception [:message]
+    end
+
+    defmodule BadHTTPCodeException do
+      defexception [:message]
+    end
 
 
 ### FinalCondition

--- a/lib/dogma/rule/exception_name.ex
+++ b/lib/dogma/rule/exception_name.ex
@@ -1,0 +1,67 @@
+defmodule Dogma.Rule.ExceptionName do
+  @moduledoc """
+  A Rule that checks that exception names end with a trailing Error.
+
+  For example, prefer this:
+
+      defmodule BadHTTPCodeError do
+        defexception [:message]
+      end
+
+  Not one of these:
+
+      defmodule BadHTTPCode do
+        defexception [:message]
+      end
+
+      defmodule BadHTTPCodeException do
+        defexception [:message]
+      end
+  """
+
+  @behaviour Dogma.Rule
+  @good_name_suffix "Error"
+
+  alias Dogma.Script
+  alias Dogma.Error
+
+  def test(script, _config = [] \\ []) do
+    script |> Script.walk( &check_node(&1, &2) )
+  end
+
+  defp check_node(
+    {:defmodule, _metadata, [{:__aliases__, _, _name_arr}, children]} = node,
+    errors
+  ) do
+    error_module? =
+      children[:do]
+      |> block_children_as_list
+      |> Enum.any?(&exception?/1)
+    name = Enum.join(_name_arr, ".")
+
+    if error_module? && bad_name?(name) do
+      {node, [error(_metadata[:line], name) | errors]}
+    else
+      {node, errors}
+    end
+  end
+  defp check_node(node, errors) do
+    {node, errors}
+  end
+
+  defp bad_name?(name), do: !String.ends_with?(name, @good_name_suffix)
+
+  def block_children_as_list({:__block__, _, children}), do: children
+  def block_children_as_list(children), do: [children]
+
+  defp exception?({:defexception, _, _}), do: true
+  defp exception?(_), do: false
+
+  defp error(line, _name) do
+    %Error{
+      rule:     __MODULE__,
+      message:  "Exception names should end with '#{@good_name_suffix}'.",
+      line: line,
+    }
+  end
+end

--- a/lib/dogma/rule_set/all.ex
+++ b/lib/dogma/rule_set/all.ex
@@ -12,6 +12,7 @@ defmodule Dogma.RuleSet.All do
       {BarePipeChainStart},
       {ComparisonToBoolean},
       {DebuggerStatement},
+      {ExceptionName},
       {FinalCondition},
       {FinalNewline},
       {FunctionArity, max: 4},

--- a/test/dogma/rule/exception_name_test.exs
+++ b/test/dogma/rule/exception_name_test.exs
@@ -1,0 +1,44 @@
+defmodule Dogma.Rule.ExceptionNameTest do
+  use ShouldI
+
+  alias Dogma.Rule.ExceptionName
+  alias Dogma.Script
+  alias Dogma.Error
+
+  defp lint(script) do
+    script |> Script.parse!( "foo.ex" ) |> ExceptionName.test
+  end
+
+  should "not error with a trailing 'Error' in the module name" do
+    errors = """
+    defmodule BadHTTPCodeError do
+      defexception [:message]
+    end
+    """ |> lint
+    assert [] == errors
+  end
+
+  should "error with any other suffix than 'Error' in the module name" do
+    errors = """
+    defmodule BadHTTPCode do
+      defexception [:message]
+    end
+    defmodule BadHTTPCodeException do
+      defexception [:message]
+    end
+    """ |> lint
+    expected_errors = [
+      %Error{
+        rule:     ExceptionName,
+        message:  "Exception names should end with 'Error'.",
+        line: 4,
+      },
+      %Error{
+        rule:     ExceptionName,
+        message:  "Exception names should end with 'Error'.",
+        line: 1,
+      },
+    ]
+    assert expected_errors == errors
+  end
+end


### PR DESCRIPTION
This PR adds a rule that checks that all exception module are named with the suffix `Error` ([elixir_style_guide reference](https://github.com/niftyn8/elixir_style_guide#exceptions))

For example, prefer this:

      defmodule BadHTTPCodeError do
        defexception [:message]
      end

Not one of these:

      defmodule BadHTTPCode do
        defexception [:message]
      end

      defmodule BadHTTPCodeException do
        defexception [:message]
      end

I think in the long run we will want to be able to configure which term is used as unified suffix, but for now this helps us achieve better "coverage" of the Elixir Styleguide by niftyn8.
