### PR TITLE
Add Dogma.version

### DIFF
--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -41,6 +41,7 @@ The JSON structure is like the following example:
 
     {
       "metadata": {
+        "dogma_version": "0.3.0",
         "elixir_version": "1.0.5",
         "erlang_version": "Erlang/OTP 10 [erts-7.0.3] [64-bit]",
         "system_architecture": "x86_64-apple-darwin14.5.0"

--- a/lib/dogma.ex
+++ b/lib/dogma.ex
@@ -10,6 +10,8 @@ defmodule Dogma do
   alias Dogma.Rules
   alias Dogma.ScriptSources
 
+  @version Mix.Project.config[:version]
+
   def run({dir, formatter}) do
     dir
     |> ScriptSources.find(exclude_patterns)
@@ -22,4 +24,6 @@ defmodule Dogma do
   defp exclude_patterns do
     Application.get_env :dogma, :exclude, []
   end
+
+  def version, do: @version
 end

--- a/lib/dogma/formatter/json.ex
+++ b/lib/dogma/formatter/json.ex
@@ -6,6 +6,7 @@ defmodule Dogma.Formatter.JSON do
 
       {
         "metadata": {
+          "dogma_version": "0.3.0",
           "elixir_version": "1.0.5",
           "erlang_version": "Erlang/OTP 10 [erts-7.0.3] [64-bit]",
           "system_architecture": "x86_64-apple-darwin14.5.0"
@@ -66,6 +67,7 @@ defmodule Dogma.Formatter.JSON do
                    |> to_string
 
     %{
+      dogma_version: Dogma.version,
       elixir_version: System.version,
       erlang_version: erl_version,
       system_architecture: architecture

--- a/test/dogma/formatter/json_test.exs
+++ b/test/dogma/formatter/json_test.exs
@@ -110,6 +110,7 @@ defmodule Dogma.Formatter.JSONTest do
 
   defp test_system_info(%{"metadata" => metadata}) do
     assert metadata == %{
+      "dogma_version"       => Dogma.version,
       "elixir_version"      => System.version,
       "erlang_version"      => erlang_version,
       "system_architecture" => system_architecture


### PR DESCRIPTION
This fixes the issue raised in #123 while keeping the version number in the JSON output **and** providing the handy `Dogma.version` function for future use.

This bug only came up because I wanted to use Dogma in a test project, where I wanted to create a custom Rule for "method length in lines" ... If you have any interests in exploring this topic of "Dogma as a dependency" further, I could open source my "wrapper code" on the weekend!