### PR TITLE
rule for interpolation-only strings

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,7 +1,7 @@
 # Dogma Rules
 
 These are the rules included in Dogma by default. Currently there are
-26 of them.
+27 of them.
 
 ## Contents
 
@@ -23,6 +23,7 @@ These are the rules included in Dogma by default. Currently there are
 * [ModuleName](#modulename)
 * [NegatedAssert](#negatedassert)
 * [NegatedIfUnless](#negatedifunless)
+* [NoInterpolationOnlyStrings](#nointerpolationonlystrings)
 * [PredicateName](#predicatename)
 * [QuotesInString](#quotesinstring)
 * [Semicolon](#semicolon)
@@ -361,6 +362,18 @@ These are considered invalid:
     unless not sad? do
       mope_about()
     end
+
+
+### NoInterpolationOnlyStrings
+
+A rule that disallows strings which are entirely the result of an
+interpolation.
+
+Good:
+    output = "Dogma.Rule.NoInterpolationOnlyStrings"
+
+Bad:
+    output = inspect(__MODULE__)
 
 
 ### PredicateName

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -370,10 +370,12 @@ A rule that disallows strings which are entirely the result of an
 interpolation.
 
 Good:
-  output = inspect(__MODULE__)
+
+      output = inspect(self)
 
 Bad:
-  output = "Dogma.Rule.NoInterpolationOnlyStrings"
+
+      output = "#{inspect self}"
 
 
 ### PredicateName

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -370,10 +370,10 @@ A rule that disallows strings which are entirely the result of an
 interpolation.
 
 Good:
-    output = "Dogma.Rule.NoInterpolationOnlyStrings"
+  output = inspect(__MODULE__)
 
 Bad:
-    output = inspect(__MODULE__)
+  output = "Dogma.Rule.NoInterpolationOnlyStrings"
 
 
 ### PredicateName

--- a/lib/dogma/rule/no_interpolation_only_strings.ex
+++ b/lib/dogma/rule/no_interpolation_only_strings.ex
@@ -30,7 +30,7 @@ defmodule Dogma.Rule.NoInterpolationOnlyStrings do
   defp error(pos) do
     %Error{
       rule:    __MODULE__,
-      message: "A string should not entirely be the value of an interpolation",
+      message: "A string should not only be the value of an interpolation",
       line:    pos,
     }
   end

--- a/lib/dogma/rule/no_interpolation_only_strings.ex
+++ b/lib/dogma/rule/no_interpolation_only_strings.ex
@@ -4,10 +4,10 @@ defmodule Dogma.Rule.NoInterpolationOnlyStrings do
   interpolation.
 
   Good:
-      output = "#{inspect __MODULE__}"
+    output = inspect(__MODULE__)
 
   Bad:
-      output = inspect(__MODULE__)
+    output = "#{inspect __MODULE__}"
   """
 
   @behaviour Dogma.Rule

--- a/lib/dogma/rule/no_interpolation_only_strings.ex
+++ b/lib/dogma/rule/no_interpolation_only_strings.ex
@@ -1,0 +1,37 @@
+defmodule Dogma.Rule.NoInterpolationOnlyStrings do
+  @moduledoc """
+  A rule that disallows strings which are entirely the result of an
+  interpolation.
+
+  Good:
+      output = "#{inspect __MODULE__}"
+
+  Bad:
+      output = inspect(__MODULE__)
+  """
+
+  @behaviour Dogma.Rule
+
+  alias Dogma.Script
+  alias Dogma.Error
+
+  def test(script, _config \\ []) do
+    script
+    |> Script.walk(&check_node(&1, &2))
+  end
+
+  defp check_node({:<<>>, meta, [{:::, _, _}]} = node, errors) do
+    {node, [ error(meta[:line]) | errors ]}
+  end
+  defp check_node(node, errors) do
+    {node, errors}
+  end
+
+  defp error(pos) do
+    %Error{
+      rule:    __MODULE__,
+      message: "A string should not entirely be the value of an interpolation",
+      line:    pos,
+    }
+  end
+end

--- a/lib/dogma/rule/no_interpolation_only_strings.ex
+++ b/lib/dogma/rule/no_interpolation_only_strings.ex
@@ -4,10 +4,12 @@ defmodule Dogma.Rule.NoInterpolationOnlyStrings do
   interpolation.
 
   Good:
-    output = inspect(__MODULE__)
+
+        output = inspect(self)
 
   Bad:
-    output = "#{inspect __MODULE__}"
+
+        output = "#\{inspect self}"
   """
 
   @behaviour Dogma.Rule

--- a/lib/dogma/rule_set/all.ex
+++ b/lib/dogma/rule_set/all.ex
@@ -27,6 +27,7 @@ defmodule Dogma.RuleSet.All do
       {ModuleName},
       {NegatedAssert},
       {NegatedIfUnless},
+      {NoInterpolationOnlyStrings},
       {PredicateName},
       {QuotesInString},
       {Semicolon},

--- a/lib/dogma/script_sources.ex
+++ b/lib/dogma/script_sources.ex
@@ -28,7 +28,7 @@ defmodule Dogma.ScriptSources do
 
   @doc """
   Takes a collection of paths to Elixir source files, and returns list of
-  Script structs representing said source files. 
+  Script structs representing said source files.
   """
   def to_scripts(paths) when is_list paths do
     for path <- paths do

--- a/test/dogma/rule/no_interpolation_only_strings_test.exs
+++ b/test/dogma/rule/no_interpolation_only_strings_test.exs
@@ -35,7 +35,7 @@ defmodule Dogma.Rule.NoInterpolationOnlyStringsTest do
   should "not error for a string which includes more than an interpolation" do
     errors = ~S"""
     who = "world"
-    Hello #{who}
+    "Hello #{who}"
     """ |> lint
     assert [] == errors
   end

--- a/test/dogma/rule/no_interpolation_only_strings_test.exs
+++ b/test/dogma/rule/no_interpolation_only_strings_test.exs
@@ -33,7 +33,7 @@ defmodule Dogma.Rule.NoInterpolationOnlyStringsTest do
   end
 
   should "not error for a string which includes more than an interpolation" do
-    errors = """
+    errors = ~S"""
     who = "world"
     Hello #{who}
     """ |> lint

--- a/test/dogma/rule/no_interpolation_only_strings_test.exs
+++ b/test/dogma/rule/no_interpolation_only_strings_test.exs
@@ -40,42 +40,6 @@ defmodule Dogma.Rule.NoInterpolationOnlyStringsTest do
     assert [] == errors
   end
 
-  should "not error for a quote in a ~s string" do
-    errors = """
-    ~s(hello, quote -> " <-)
-    """ |> lint
-    assert [] == errors
-  end
-
-  should "not error for a quote in a ~r regex" do
-    errors = """
-    ~r/"/
-    """ |> lint
-    assert [] == errors
-  end
-
-  should "not error for a quote in a ~R regex" do
-    errors = """
-    ~R/"/
-    """ |> lint
-    assert [] == errors
-  end
-
-  should "not error for a quote in a ~S string" do
-    errors = """
-    ~S(hello, quote -> " <-)
-    """ |> lint
-    assert [] == errors
-  end
-
-  should "not error for a quote in a heredoc" do
-    errors = ~s(
-    """
-    Hey look, a quote -> "
-    """) |> lint
-    assert [] == errors
-  end
-
   should "not error for a quote in a binary literal" do
     errors = ~S"""
     << "\""::utf8, cs::binary >> = string

--- a/test/dogma/rule/no_interpolation_only_strings_test.exs
+++ b/test/dogma/rule/no_interpolation_only_strings_test.exs
@@ -1,0 +1,85 @@
+defmodule Dogma.Rule.NoInterpolationOnlyStringsTest do
+  use ShouldI
+
+  alias Dogma.Rule.NoInterpolationOnlyStrings
+  alias Dogma.Script
+  alias Dogma.Error
+
+  defp lint(script) do
+    script
+    |> Script.parse!("foo.ex")
+    |> NoInterpolationOnlyStrings.test
+  end
+
+  should "error for an interpolation-only string" do
+    errors = ~S"""
+    "#{inspect app_servers_pids}"
+    """ |> lint
+    expected_errors = [
+      %Error{
+        rule: NoInterpolationOnlyStrings,
+        message: "A string should not entirely be the value of an interpolation",
+        line: 1,
+      }
+    ]
+    assert expected_errors == errors
+  end
+
+  should "not error for a string which does not include an interpolation" do
+    errors = """
+    "Hello, world!"
+    """ |> lint
+    assert [] == errors
+  end
+
+  should "not error for a string which includes more than an interpolation" do
+    errors = """
+    who = "world"
+    Hello #{who}
+    """ |> lint
+    assert [] == errors
+  end
+
+  should "not error for a quote in a ~s string" do
+    errors = """
+    ~s(hello, quote -> " <-)
+    """ |> lint
+    assert [] == errors
+  end
+
+  should "not error for a quote in a ~r regex" do
+    errors = """
+    ~r/"/
+    """ |> lint
+    assert [] == errors
+  end
+
+  should "not error for a quote in a ~R regex" do
+    errors = """
+    ~R/"/
+    """ |> lint
+    assert [] == errors
+  end
+
+  should "not error for a quote in a ~S string" do
+    errors = """
+    ~S(hello, quote -> " <-)
+    """ |> lint
+    assert [] == errors
+  end
+
+  should "not error for a quote in a heredoc" do
+    errors = ~s(
+    """
+    Hey look, a quote -> "
+    """) |> lint
+    assert [] == errors
+  end
+
+  should "not error for a quote in a binary literal" do
+    errors = ~S"""
+    << "\""::utf8, cs::binary >> = string
+    """ |> lint
+    assert [] == errors
+  end
+end

--- a/test/dogma/rule/no_interpolation_only_strings_test.exs
+++ b/test/dogma/rule/no_interpolation_only_strings_test.exs
@@ -18,7 +18,7 @@ defmodule Dogma.Rule.NoInterpolationOnlyStringsTest do
     expected_errors = [
       %Error{
         rule: NoInterpolationOnlyStrings,
-        message: "A string should not entirely be the value of an interpolation",
+        message: "A string should not only be the value of an interpolation",
         line: 1,
       }
     ]

--- a/test/dogma/rule/quotes_in_string_test.exs
+++ b/test/dogma/rule/quotes_in_string_test.exs
@@ -54,7 +54,7 @@ defmodule Dogma.Rule.QuotesInStringTest do
 
   should "not error for a quote in a ~R regex" do
     errors = """
-    ~r/"/
+    ~R/"/
     """ |> lint
     assert [] == errors
   end


### PR DESCRIPTION
Rule to favor `foo(bar)` over `"#{foo(bar)}"`.

Not sure if this covers nested strings or destructuring or other interesting/edge cases...