### PR TITLE
New rule: CommentFormat

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,10 +1,11 @@
 # Dogma Rules
 
 These are the rules included in Dogma by default. Currently there are
-29 of them.
+30 of them.
 
 ## Contents
 
+* [CommentFormat](#commentformat)
 * [ComparisonToBoolean](#comparisontoboolean)
 * [DebuggerStatement](#debuggerstatement)
 * [ExceptionName](#exceptionname)
@@ -37,6 +38,10 @@ These are the rules included in Dogma by default. Currently there are
 
 
 ---
+
+### CommentFormat
+
+
 
 ### ComparisonToBoolean
 

--- a/lib/dogma/rule/comment_format.ex
+++ b/lib/dogma/rule/comment_format.ex
@@ -1,0 +1,34 @@
+defmodule Dogma.Rule.CommentFormat do
+  @moduledoc """
+  """
+
+  @behaviour Dogma.Rule
+
+  alias Dogma.Error
+
+  def test(script, _config = [] \\ []) do
+    script.comments |> Enum.reduce([], &check_comment/2)
+  end
+
+
+  defp check_comment(comment, errors) do
+    case comment.content do
+      "" ->
+        errors
+
+      << " "::utf8, _::binary >> ->
+        errors
+
+      _ ->
+        [error( comment.line ) | errors]
+    end
+  end
+
+  defp error(pos) do
+    %Error{
+      rule:    __MODULE__,
+      message: "Comments should start with a single space",
+      line:    pos
+    }
+  end
+end

--- a/lib/dogma/rule_set/all.ex
+++ b/lib/dogma/rule_set/all.ex
@@ -9,6 +9,7 @@ defmodule Dogma.RuleSet.All do
 
   def rules do
     %{
+      CommentFormat           => [],
       ComparisonToBoolean     => [],
       DebuggerStatement       => [],
       ExceptionName           => [],

--- a/lib/dogma/script.ex
+++ b/lib/dogma/script.ex
@@ -12,7 +12,8 @@ defmodule Dogma.Script do
 
   alias Dogma.Script
   alias Dogma.Error
-  # alias Dogma.Util.Comment
+  alias Dogma.Util.Comment
+  alias Dogma.Util.ScriptSigils
   alias Dogma.Util.ScriptStrings
   alias Dogma.Util.Lines
 
@@ -24,7 +25,7 @@ defmodule Dogma.Script do
             ast:              nil,
             tokens:           nil,
             valid?:           nil,
-            # comments:         nil,
+            comments:         nil,
             errors:           []
 
 
@@ -32,14 +33,14 @@ defmodule Dogma.Script do
   Builds a Script struct from the given source code and path
   """
   def parse(source, path) do
-    processed_source = ScriptStrings.strip( source )
+    processed_source = source |> ScriptSigils.strip |> ScriptStrings.strip
     %Script{
       path:             path,
       source:           source,
       lines:            Lines.get( source ),
       processed_source: processed_source,
       processed_lines:  Lines.get( processed_source ),
-    } |> add_ast |> add_tokens # |> add_comments
+    } |> add_ast |> add_tokens |> add_comments
   end
 
   @doc """
@@ -74,10 +75,10 @@ defmodule Dogma.Script do
     end
   end
 
-  # defp add_comments(script) do
-  #   comments = script.processed_lines |> Comment.get_all
-  #   %Script{ script | comments: comments }
-  # end
+  defp add_comments(script) do
+    comments = script.processed_lines |> Comment.get_all
+    %Script{ script | comments: comments }
+  end
 
   defp tokenize(source) do
     result =

--- a/lib/dogma/util/script_sigils.ex
+++ b/lib/dogma/util/script_sigils.ex
@@ -11,7 +11,7 @@ defmodule Dogma.Util.ScriptSigils do
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" |> String.graphemes
 
   sigil_delimiters = [
-    "||", ~S(""), "''", "()", "[]", "{}", "<>",
+    "||", ~S(""), "''", "()", "[]", "{}", "<>", "//",
   ] |> Enum.map(&String.graphemes/1)
 
   sigils = for(

--- a/lib/dogma/util/script_strings.ex
+++ b/lib/dogma/util/script_strings.ex
@@ -7,13 +7,6 @@ defmodule Dogma.Util.ScriptStrings do
   for Elixir code and reporting errors when there should be none.
   """
 
-  # @sigil_delimiters [{"|", "|"}, {~S("), ~S(")}, {"'", "'"}, {"(", ")"},
-  #                     {"[", "]"}, {"{", "}"}, {"<", ">"}]
-  # @all_string_sigils @sigil_delimiters
-  #                     |> Enum.flat_map(fn({b, e}) ->
-  #                         [{"~s#{b}", e}, {"~S#{b}", e}]
-  #                       end)
-
   @doc """
   Takes a source string and return it with all of the string literals stripped
   of their contents.
@@ -25,11 +18,6 @@ defmodule Dogma.Util.ScriptStrings do
   defp parse_code("", acc) do
     acc
   end
-  # for {sigil_start, sigil_end} <- @all_string_sigils do
-  #   defp parse_code(<< unquote(sigil_start)::utf8, t::binary >>, acc) do
-  #     parse_string_sigil(t, acc <> unquote(sigil_start), unquote(sigil_end))
-  #   end
-  # end
   defp parse_code(<< "\\\""::utf8, t::binary >>, acc) do
     parse_code(t, acc <> ~s(\\"))
   end
@@ -64,32 +52,6 @@ defmodule Dogma.Util.ScriptStrings do
   defp parse_string_literal(<< _::utf8, t::binary >>, acc) do
     parse_string_literal(t, acc)
   end
-
-  # for {_sigil_start, sigil_end} <- @all_string_sigils do
-  #   defp parse_string_sigil("", acc, unquote(sigil_end)) do
-  #     acc
-  #   end
-  #   defp parse_string_sigil(<< "\\\\"::utf8, t::binary >>, acc,
-  #                                                       unquote(sigil_end)) do
-  #     parse_string_sigil(t, acc, unquote(sigil_end))
-  #   end
-  #   defp parse_string_sigil(<< "\\\""::utf8, t::binary >>, acc,
-  #                                                       unquote(sigil_end)) do
-  #     parse_string_sigil(t, acc, unquote(sigil_end))
-  #   end
-  #   defp parse_string_sigil(<< unquote(sigil_end)::utf8, t::binary >>, acc,
-  #                                                       unquote(sigil_end)) do
-  #     parse_code(t, acc <> unquote(sigil_end))
-  #   end
-  #   defp parse_string_sigil(<< "\n"::utf8, t::binary >>, acc,
-  #                                                       unquote(sigil_end)) do
-  #     parse_string_sigil(t, acc <> "\n", unquote(sigil_end))
-  #   end
-  #   defp parse_string_sigil(<< _::utf8, t::binary >>, acc,
-  #                                                       unquote(sigil_end)) do
-  #     parse_string_sigil(t, acc, unquote(sigil_end))
-  #   end
-  # end
 
   defp parse_heredoc("", acc) do
     acc

--- a/test/dogma/rule/comment_format_test.exs
+++ b/test/dogma/rule/comment_format_test.exs
@@ -1,0 +1,51 @@
+defmodule Dogma.Rule.CommentFormatTest do
+  use ShouldI
+
+  alias Dogma.Rule.CommentFormat
+  alias Dogma.Script
+  alias Dogma.Error
+
+  defp lint(script) do
+    script |> Script.parse!( "foo.ex" ) |> CommentFormat.test
+  end
+
+  should "not error with a space after the #" do
+    errors = """
+    1 + 1 # Hello, world!
+    """ |> lint
+    assert [] == errors
+  end
+
+  should "not error with no content after the #" do
+    errors = """
+    # This is cool.
+    #
+    1 + 1
+    """ |> lint
+    assert [] == errors
+  end
+
+  should "error with not space after the #" do
+    errors = """
+    1 + 1 #Hello, world!
+    """ |> lint
+    expected_errors = [
+      %Error{
+        line: 1,
+        message: "Comments should start with a single space",
+        rule: CommentFormat
+      }
+    ]
+    assert expected_errors == errors
+  end
+
+  should "not error with not multiple spaces after the #" do
+    errors = """
+    "Hi!"
+    1 + 1 #     Hello, world!
+    """ |> lint
+    expected_errors = [
+    ]
+    assert expected_errors == errors
+  end
+end

--- a/test/dogma/script_test.exs
+++ b/test/dogma/script_test.exs
@@ -4,7 +4,7 @@ defmodule Dogma.ScriptTest do
   alias Dogma.Error
   alias Dogma.Script
   alias Dogma.Script.InvalidScriptError
-  # alias Dogma.Util.Comment
+  alias Dogma.Util.Comment
 
   with "parse/2" do
 
@@ -92,13 +92,11 @@ defmodule Dogma.ScriptTest do
         ] = context.script.tokens
       end
 
-      @tag :skip
-      should "assign comments", _context do
-        DogmaTest.Helper.pending
-        # assert context.script.comments == [
-        #   %Comment{ content: " Comment", line: 3 },
-        #   %Comment{ content: " Another", line: 4 },
-        # ]
+      should "assign comments", context do
+        assert context.script.comments == [
+          %Comment{ content: " Comment", line: 3 },
+          %Comment{ content: " Another", line: 4 },
+        ]
       end
     end
 

--- a/test/dogma/util/comment_test.exs
+++ b/test/dogma/util/comment_test.exs
@@ -2,11 +2,13 @@ defmodule Dogma.Util.CommentsTest do
   use ShouldI
 
   alias Dogma.Util.Lines
+  alias Dogma.Util.ScriptSigils
   alias Dogma.Util.ScriptStrings
   alias Dogma.Util.Comment
 
   def run(source) do
     source
+    |> ScriptSigils.strip
     |> ScriptStrings.strip
     |> Lines.get
     |> Comment.get_all
@@ -30,14 +32,12 @@ defmodule Dogma.Util.CommentsTest do
     assert comments == expected
   end
 
-  @tag :skip
   should "not mistake a # in a sigil for a comment" do
-    DogmaTest.Helper.pending
-    # comments = """
-    # ~r/#/
-    # ~S" # "
-    # ~w( # # # )
-    # """ |> run
-    # assert comments == []
+    comments = """
+    ~r/#/
+    ~S" # "
+    ~w( # # # )
+    """ |> run
+    assert comments == []
   end
 end

--- a/test/dogma/util/script_sigils_test.exs
+++ b/test/dogma/util/script_sigils_test.exs
@@ -49,6 +49,7 @@ defmodule Dogma.Util.ScriptSigilsTest do
             ~#{unquote(char)}[Hello, world]
             ~#{unquote(char)}{Hello, world}
             ~#{unquote(char)}<Hello, world>
+            ~#{unquote(char)}/Hello, world/
           end
         end
         """
@@ -62,6 +63,7 @@ defmodule Dogma.Util.ScriptSigilsTest do
             ~#{unquote(char)}[]
             ~#{unquote(char)}{}
             ~#{unquote(char)}<>
+            ~#{unquote(char)}//
           end
         end
         """
@@ -80,6 +82,7 @@ defmodule Dogma.Util.ScriptSigilsTest do
           ~s[Hello, \] world]
           ~s{Hello, \} world}
           ~s<Hello, \> world>
+          ~s/Hello, \/ world/
         end
       end
       """
@@ -93,6 +96,7 @@ defmodule Dogma.Util.ScriptSigilsTest do
           ~s[]
           ~s{}
           ~s<>
+          ~s//
         end
       end
       """


### PR DESCRIPTION
We can't use this yet because comment detection can't tell the different between a comment hash and a hash inside a sigil.