### PR TITLE
Add better string removal

### DIFF
--- a/lib/dogma/util/script_strings.ex
+++ b/lib/dogma/util/script_strings.ex
@@ -7,7 +7,7 @@ defmodule Dogma.Util.ScriptStrings do
   for Elixir code and reporting errors when there should be none.
   """
 
-  @sigil_delimiters [{"|", "|"}, {"\"", "\""}, {"'", "'"}, {"(", ")"},
+  @sigil_delimiters [{"|", "|"}, {~S("), ~S(")}, {"'", "'"}, {"(", ")"},
                       {"[", "]"}, {"{", "}"}, {"<", ">"}]
   @all_string_sigils @sigil_delimiters
                       |> Enum.flat_map(fn({b, e}) ->
@@ -31,16 +31,16 @@ defmodule Dogma.Util.ScriptStrings do
     end
   end
   defp parse_code(<< "\\\""::utf8, t::binary >>, acc) do
-    parse_code(t, acc <> "\\\"")
+    parse_code(t, acc <> ~s(\\"))
   end
   defp parse_code(<< "?\""::utf8, t::binary >>, acc) do
-    parse_code(t, acc <> "?\"")
+    parse_code(t, acc <> ~S(?"))
   end
   defp parse_code(<< "\"\"\""::utf8, t::binary >>, acc) do
     parse_heredoc(t, acc <> ~s("""))
   end
   defp parse_code(<< "\""::utf8, t::binary >>, acc) do
-    parse_string_literal(t, acc <> "\"")
+    parse_string_literal(t, acc <> ~S("))
   end
   defp parse_code(<< h::utf8, t::binary >>, acc) do
     parse_code(t, acc <> <<h>>)
@@ -69,19 +69,24 @@ defmodule Dogma.Util.ScriptStrings do
     defp parse_string_sigil("", acc, unquote(sigil_end)) do
       acc
     end
-    defp parse_string_sigil(<< "\\\\"::utf8, t::binary >>, acc, unquote(sigil_end)) do
+    defp parse_string_sigil(<< "\\\\"::utf8, t::binary >>, acc,
+                                                        unquote(sigil_end)) do
       parse_string_sigil(t, acc, unquote(sigil_end))
     end
-    defp parse_string_sigil(<< "\\\""::utf8, t::binary >>, acc, unquote(sigil_end)) do
+    defp parse_string_sigil(<< "\\\""::utf8, t::binary >>, acc,
+                                                        unquote(sigil_end)) do
       parse_string_sigil(t, acc, unquote(sigil_end))
     end
-    defp parse_string_sigil(<< unquote(sigil_end)::utf8, t::binary >>, acc, unquote(sigil_end)) do
+    defp parse_string_sigil(<< unquote(sigil_end)::utf8, t::binary >>, acc,
+                                                        unquote(sigil_end)) do
       parse_code(t, acc <> unquote(sigil_end))
     end
-    defp parse_string_sigil(<< "\n"::utf8, t::binary >>, acc, unquote(sigil_end)) do
+    defp parse_string_sigil(<< "\n"::utf8, t::binary >>, acc,
+                                                        unquote(sigil_end)) do
       parse_string_sigil(t, acc <> "\n", unquote(sigil_end))
     end
-    defp parse_string_sigil(<< _::utf8, t::binary >>, acc, unquote(sigil_end)) do
+    defp parse_string_sigil(<< _::utf8, t::binary >>, acc,
+                                                        unquote(sigil_end)) do
       parse_string_sigil(t, acc, unquote(sigil_end))
     end
   end

--- a/test/dogma/util/script_strings_test.exs
+++ b/test/dogma/util/script_strings_test.exs
@@ -21,11 +21,11 @@ defmodule Dogma.Util.ScriptStringsTest do
       assert processed == script
     end
 
-    should "no-op with with s sigil" do
+    should "no-op with double quote character (?\")" do
       script = """
-      defmodule Sneaky do
-        def String do
-          ~s(Hey, look, this is a string!)
+      defmodule Hello do
+        def World do
+          [?", :dennis_rocks]
         end
       end
       """
@@ -33,7 +33,25 @@ defmodule Dogma.Util.ScriptStringsTest do
       assert processed == script
     end
 
-    should "no-op with with S sigil" do
+    should "strip contents from s sigil" do
+      script = """
+      defmodule Sneaky do
+        def String do
+          ~s(Hey, look, this is a string!)
+        end
+      end
+      """
+      desired = """
+      defmodule Sneaky do
+        def String do
+          ~s()
+        end
+      end
+      """
+      assert desired == script |> ScriptStrings.blank
+    end
+
+    should "strip contents from S sigil" do
       script = """
       defmodule Sneaky do
         def String do
@@ -41,8 +59,14 @@ defmodule Dogma.Util.ScriptStringsTest do
         end
       end
       """
-      processed = script |> ScriptStrings.blank
-      assert processed == script
+      desired = """
+      defmodule Sneaky do
+        def String do
+          ~S()
+        end
+      end
+      """
+      assert desired == script |> ScriptStrings.blank
     end
 
     should "strip contents from strings, preserving newlines" do

--- a/test/dogma/util/script_strings_test.exs
+++ b/test/dogma/util/script_strings_test.exs
@@ -21,7 +21,7 @@ defmodule Dogma.Util.ScriptStringsTest do
       assert processed == script
     end
 
-    should "no-op with double quote character (?\")" do
+    should ~S{no-op with double quote character (?")} do
       script = """
       defmodule Hello do
         def World do


### PR DESCRIPTION
Hi there, long time no see. I was working on a prototype for an Elixir parser/toolbox/linter and noticed [this comment of yours](https://github.com/lpil/dogma/pull/149) about `Dogma.ScriptStrings` still falling short. :sob: 

This PR adds two more edge cases to the test suite where `ScriptStrings` was failing and adds the code I developed for my own project to resolve these cases.  The public API of `ScriptStrings` was *not* altered (I adapted my code) and you should be able to finish your Comment rule soon. :grin: