### PR TITLE
Allow linting of single files

### DIFF
--- a/lib/dogma.ex
+++ b/lib/dogma.ex
@@ -12,8 +12,8 @@ defmodule Dogma do
 
   @version Mix.Project.config[:version]
 
-  def run(dir, config, formatter) do
-    dir
+  def run(dir_or_file, config, formatter) do
+    dir_or_file
     |> ScriptSources.find(config.exclude)
     |> ScriptSources.to_scripts
     |> Formatter.start(formatter)

--- a/lib/dogma/script_sources.ex
+++ b/lib/dogma/script_sources.ex
@@ -19,20 +19,15 @@ defmodule Dogma.ScriptSources do
   """
   def find(path, exclude_patterns \\ []) when is_list exclude_patterns do
     path = to_string path # Convert nil to ""
-    case File.regular? path do
-      true ->
-        case String.ends_with? path, [".ex", ".exs"] do
-          true ->
-            [path]
-          false ->
-            []
-        end
+    case resolve_file path do
       false ->
         path
         |> Path.join( "**/*.{ex,exs}" )
         |> Path.wildcard
         |> Enum.reject( &String.starts_with?(&1, @ignored_dirs) )
         |> Enum.reject( &match_any?(&1, exclude_patterns) )
+      files ->
+        files
     end
   end
 
@@ -55,4 +50,19 @@ defmodule Dogma.ScriptSources do
       Regex.match?( regex, string )
     end)
   end
+
+  defp resolve_file(path) do
+    case File.regular? path do
+      true ->
+        case String.ends_with? path, [".ex", ".exs"] do
+          true ->
+            [path]
+          false ->
+            []
+        end
+      false ->
+        false
+    end
+  end
+
 end

--- a/lib/dogma/script_sources.ex
+++ b/lib/dogma/script_sources.ex
@@ -18,6 +18,7 @@ defmodule Dogma.ScriptSources do
   any of these regexes will not be returned.
   """
   def find(path, exclude_patterns \\ []) when is_list exclude_patterns do
+    path = to_string path # Convert nil to ""
     case File.regular? path do
       true ->
         case String.ends_with? path, [".ex", ".exs"] do
@@ -28,7 +29,6 @@ defmodule Dogma.ScriptSources do
         end
       false ->
         path
-        |> to_string # Convert nil to ""
         |> Path.join( "**/*.{ex,exs}" )
         |> Path.wildcard
         |> Enum.reject( &String.starts_with?(&1, @ignored_dirs) )

--- a/lib/dogma/script_sources.ex
+++ b/lib/dogma/script_sources.ex
@@ -17,13 +17,23 @@ defmodule Dogma.ScriptSources do
   The `exclude_patterns` argument is a list of regexes. File paths that match
   any of these regexes will not be returned.
   """
-  def find(dir_path, exclude_patterns \\ []) when is_list exclude_patterns do
-    dir_path
-    |> to_string # Convert nil to ""
-    |> Path.join( "**/*.{ex,exs}" )
-    |> Path.wildcard
-    |> Enum.reject( &String.starts_with?(&1, @ignored_dirs) )
-    |> Enum.reject( &match_any?(&1, exclude_patterns) )
+  def find(path, exclude_patterns \\ []) when is_list exclude_patterns do
+    case File.regular? path do
+      true ->
+        case String.ends_with? path, [".ex", ".exs"] do
+          true ->
+            [path]
+          false ->
+            []
+        end
+      false ->
+        path
+        |> to_string # Convert nil to ""
+        |> Path.join( "**/*.{ex,exs}" )
+        |> Path.wildcard
+        |> Enum.reject( &String.starts_with?(&1, @ignored_dirs) )
+        |> Enum.reject( &match_any?(&1, exclude_patterns) )
+    end
   end
 
   @doc """


### PR DESCRIPTION
Example: `mix dogma config/config.ex`

Works for `.ex` and `.exs` files

Ref #33 