### PR TITLE
Allow disabling the unix exit code via `--noerrors`

### DIFF
--- a/lib/mix/tasks/dogma.ex
+++ b/lib/mix/tasks/dogma.ex
@@ -8,24 +8,24 @@ defmodule Mix.Tasks.Dogma do
   alias Dogma.Formatter
 
   def run(argv) do
-    {dir, formatter, noerrors} = argv |> parse_args
+    {dir, formatter, noerror} = argv |> parse_args
     config = Config.build
 
     dir
     |> Dogma.run(config, formatter)
     |> any_errors?
     |> if do
-      unless noerrors do
+      unless noerror do
         System.halt(666)
       end
     end
   end
 
   def parse_args(argv) do
-    switches = [format: :string, noerrors: :boolean]
+    switches = [format: :string, error: :boolean]
     {switches, files, []} = OptionParser.parse(argv, switches: switches)
 
-    noerrors = Keyword.get(switches, :noerrors, false)
+    noerror = !Keyword.get(switches, :error, true)
     format = Keyword.get(switches, :format)
     formatter = Map.get(
       Formatter.formatters,
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.Dogma do
       Formatter.default_formatter
     )
 
-    {List.first(files), formatter, noerrors}
+    {List.first(files), formatter, noerror}
   end
 
   defp any_errors?(scripts) do

--- a/lib/mix/tasks/dogma.ex
+++ b/lib/mix/tasks/dogma.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Dogma do
     |> Dogma.run(config, formatter)
     |> any_errors?
     |> if do
-      if !noerrors do
+      unless noerrors do
         System.halt(666)
       end
     end

--- a/lib/mix/tasks/dogma.ex
+++ b/lib/mix/tasks/dogma.ex
@@ -8,21 +8,24 @@ defmodule Mix.Tasks.Dogma do
   alias Dogma.Formatter
 
   def run(argv) do
-    {dir, formatter} = argv |> parse_args
+    {dir, formatter, noerrors} = argv |> parse_args
     config = Config.build
 
     dir
     |> Dogma.run(config, formatter)
     |> any_errors?
     |> if do
-      System.halt(666)
+      if !noerrors do
+        System.halt(666)
+      end
     end
   end
 
   def parse_args(argv) do
-    switches = [format: :string]
+    switches = [format: :string, noerrors: :boolean]
     {switches, files, []} = OptionParser.parse(argv, switches: switches)
 
+    noerrors = Keyword.get(switches, :noerrors, false)
     format = Keyword.get(switches, :format)
     formatter = Map.get(
       Formatter.formatters,
@@ -30,7 +33,7 @@ defmodule Mix.Tasks.Dogma do
       Formatter.default_formatter
     )
 
-    {List.first(files), formatter}
+    {List.first(files), formatter, noerrors}
   end
 
   defp any_errors?(scripts) do

--- a/test/mix/tasks/dogma_test.exs
+++ b/test/mix/tasks/dogma_test.exs
@@ -50,9 +50,9 @@ defmodule Dogma.OptionParserTest do
       end
     end
 
-    with "noerrors option passed" do
+    with "no-error option passed" do
       should "return disabled error exit code" do
-        parsed = parse_args(["--noerrors"])
+        parsed = parse_args(["--no-error"])
         assert parsed == {nil, @default_formatter, true}
       end
     end

--- a/test/mix/tasks/dogma_test.exs
+++ b/test/mix/tasks/dogma_test.exs
@@ -52,8 +52,8 @@ defmodule Dogma.OptionParserTest do
 
     with "noerrors option passed" do
       should "return disabled error exit code" do
-          parsed = parse_args(["--noerrors"])
-          assert parsed == {nil, @default_formatter, true}
+        parsed = parse_args(["--noerrors"])
+        assert parsed == {nil, @default_formatter, true}
       end
     end
   end

--- a/test/mix/tasks/dogma_test.exs
+++ b/test/mix/tasks/dogma_test.exs
@@ -10,19 +10,19 @@ defmodule Dogma.OptionParserTest do
   with ".parse_args" do
     with "empty args" do
       should "return nil and default formatter" do
-        assert parse_args([]) == {nil, @default_formatter}
+        assert parse_args([]) == {nil, @default_formatter, false}
       end
     end
 
     with "directories given" do
       should "return directory and default formatter" do
-        assert parse_args(["lib/foo"]) == {"lib/foo", @default_formatter}
+        assert parse_args(["lib/foo"]) == {"lib/foo", @default_formatter, false}
       end
 
       with "multiple directories given" do
         should "return first directory only" do
           parsed = parse_args(["lib/foo", "lib/bar"])
-          assert parsed == {"lib/foo", @default_formatter}
+          assert parsed == {"lib/foo", @default_formatter, false}
         end
       end
     end
@@ -31,22 +31,29 @@ defmodule Dogma.OptionParserTest do
       with "simple passed" do
         should "return simple formatter" do
           parsed = parse_args(["--format", "simple"])
-          assert parsed == {nil, Dogma.Formatter.Simple}
+          assert parsed == {nil, Dogma.Formatter.Simple, false}
         end
       end
 
       with "flycheck passed" do
         should "return flycheck formatter" do
           parsed = parse_args(["--format=flycheck"])
-          assert parsed == {nil, Dogma.Formatter.Flycheck}
+          assert parsed == {nil, Dogma.Formatter.Flycheck, false}
         end
       end
 
       with "unknown formatter passed" do
         should "return default formatter" do
           parsed = parse_args(["--format", "false"])
-          assert parsed == {nil, @default_formatter}
+          assert parsed == {nil, @default_formatter, false}
         end
+      end
+    end
+
+    with "noerrors option passed" do
+      should "return disabled error exit code" do
+          parsed = parse_args(["--noerrors"])
+          assert parsed == {nil, @default_formatter, true}
       end
     end
   end


### PR DESCRIPTION
This is useful when using linting as part of a CI pipeline which would
otherwise stop when an exit code other than `0` is returned, while one
is only interested in the text results of the linter.