### PR TITLE
Fix broken Hex docs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ mix dogma      # Dogfooding- run the linter!
 
 Check them out on [hexdocs][hexdocs-dogma], or generate them yourself:
 
-[hexdocs-dogma]: http://hexdocs.pm/dogma/overview.html
+[hexdocs-dogma]: http://hexdocs.pm/dogma/extra-api-reference.html
 
 ```sh
 mix docs


### PR DESCRIPTION
This fixes the broken Hex docs link.