### PR TITLE
New rule: FunctionParentheses

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,7 +1,7 @@
 # Dogma Rules
 
 These are the rules included in Dogma by default. Currently there are
-27 of them.
+28 of them.
 
 ## Contents
 
@@ -12,6 +12,7 @@ These are the rules included in Dogma by default. Currently there are
 * [FinalNewline](#finalnewline)
 * [FunctionArity](#functionarity)
 * [FunctionName](#functionname)
+* [FunctionParentheses](#functionparentheses)
 * [HardTabs](#hardtabs)
 * [InterpolationOnlyString](#interpolationonlystring)
 * [LineLength](#linelength)
@@ -189,6 +190,32 @@ But it considers these invalid:
 
     defp myBelly do
       :empty
+    end
+
+
+### FunctionParentheses
+
+A rule that ensures function declarations use parentheses if and only if
+they have arguments.
+
+For example, this rule considers these function declarations valid:
+
+    def foo do
+      :bar
+    end
+
+    defp baz(a, b) do
+      :fudd
+    end
+
+But it considers these invalid:
+
+    def foo() do
+      :bar
+    end
+
+    defp baz a, b do
+      :fudd
     end
 
 

--- a/lib/dogma/rule/function_parentheses.ex
+++ b/lib/dogma/rule/function_parentheses.ex
@@ -1,0 +1,86 @@
+defmodule Dogma.Rule.FunctionParentheses do
+  @moduledoc """
+  A rule that ensures function declarations use parentheses if and only if
+  they have arguments.
+
+  For example, this rule considers these function declarations valid:
+
+      def foo do
+        :bar
+      end
+
+      defp baz(a, b) do
+        :fudd
+      end
+
+  But it considers these invalid:
+
+      def foo() do
+        :bar
+      end
+
+      defp baz a, b do
+        :fudd
+      end
+  """
+
+  @behaviour Dogma.Rule
+
+  alias Dogma.Error
+
+  def test(script, _config = [] \\ []) do
+    script.tokens |> check_function_parens
+  end
+
+  defp check_function_parens(tokens, acc \\ [])
+
+  defp check_function_parens([], acc) do
+    Enum.reverse(acc)
+  end
+
+  defp check_function_parens([{:identifier, _, :def} | rest], acc) do
+    inside_function_def(rest, acc)
+  end
+
+  defp check_function_parens([{:identifier, _, :defp} | rest], acc) do
+    inside_function_def(rest, acc)
+  end
+
+  defp check_function_parens([_ | rest], acc) do
+    check_function_parens(rest, acc)
+  end
+
+  defp inside_function_def([{:paren_identifier, _, _} | rest], acc) do
+    inside_function_name(rest, acc)
+  end
+
+  defp inside_function_def([{:identifier, _, _} | rest], acc) do
+    inside_function_name(rest, acc)
+  end
+
+  defp inside_function_def([_ | rest], acc) do
+    check_function_parens(rest, acc)
+  end
+
+  defp inside_function_name([{:"(", line} | [{:")", _} | rest]], acc) do
+    check_function_parens(rest, [error(line) | acc])
+  end
+
+  defp inside_function_name([{:identifier, line, _} | rest], acc) do
+    check_function_parens(rest, [error(line) | acc])
+  end
+
+  defp inside_function_name([_ | rest], acc) do
+    check_function_parens(rest, acc)
+  end
+
+  defp error(line) do
+    %Error{
+      rule:    __MODULE__,
+      message: "Functions declarations should have parentheses if and " <>
+        "only if they have arguments",
+      line:    Dogma.Script.line(line),
+    }
+  end
+
+end

--- a/lib/dogma/rule_set/all.ex
+++ b/lib/dogma/rule_set/all.ex
@@ -16,6 +16,7 @@ defmodule Dogma.RuleSet.All do
       FinalNewline            => [],
       FunctionArity           => [max: 4],
       FunctionName            => [],
+      FunctionParentheses     => [],
       HardTabs                => [],
       InterpolationOnlyString => [],
       LineLength              => [max_length: 80],

--- a/test/dogma/rule/function_parentheses_test.exs
+++ b/test/dogma/rule/function_parentheses_test.exs
@@ -1,0 +1,117 @@
+defmodule Dogma.Rule.FunctionParenthesesTest do
+  use ShouldI
+
+  alias Dogma.Rule.FunctionParentheses
+  alias Dogma.Script
+  alias Dogma.Error
+
+  defp lint(script) do
+    script |> Script.parse!( "foo.ex" ) |> FunctionParentheses.test
+  end
+
+  should "not error without parentheses and without argument" do
+    errors = """
+    def foo do
+    end
+    def foo_bar do
+    end
+    defp private_foo do
+    end
+    def baz, do: :baz
+    """ |> lint
+    assert [] == errors
+  end
+
+  should "not error with parentheses and arguments" do
+    errors = """
+    def foo(a) do
+    end
+    def foo_bar(a, b, c) do
+    end
+    defp private_foo(x, y) do
+    end
+    def baz(z), do: z
+    """ |> lint
+    assert [] == errors
+  end
+
+  should "error with public function with parentheses and without arguments" do
+    errors = """
+    def foo() do
+    end
+    """ |> lint
+    expected_errors = [
+      %Error{
+        rule: FunctionParentheses,
+        message: "Functions declarations should have parentheses if and " <>
+          "only if they have arguments",
+        line: 1
+      }
+    ]
+    assert expected_errors == errors
+  end
+
+  should "error with private function with parentheses and without arguments" do
+    errors = """
+    defp foo() do
+    end
+    """ |> lint
+    expected_errors = [
+      %Error{
+        rule: FunctionParentheses,
+        message: "Functions declarations should have parentheses if and " <>
+          "only if they have arguments",
+        line: 1
+      }
+    ]
+    assert expected_errors == errors
+  end
+
+  should "error with single-line function parentheses and without arguments" do
+    errors = """
+    def foo(), do: :bar
+    """ |> lint
+    expected_errors = [
+      %Error{
+        rule: FunctionParentheses,
+        message: "Functions declarations should have parentheses if and " <>
+          "only if they have arguments",
+        line: 1
+      }
+    ]
+    assert expected_errors == errors
+  end
+
+  should "error with public function without parentheses and with arguments" do
+    errors = """
+    def foo a, b do
+    end
+    """ |> lint
+    expected_errors = [
+      %Error{
+        rule: FunctionParentheses,
+        message: "Functions declarations should have parentheses if and " <>
+          "only if they have arguments",
+        line: 1
+      }
+    ]
+    assert expected_errors == errors
+  end
+
+  should "error with private function without parentheses and with arguments" do
+    errors = """
+    defp foo a, b do
+    end
+    """ |> lint
+    expected_errors = [
+      %Error{
+        rule: FunctionParentheses,
+        message: "Functions declarations should have parentheses if and " <>
+          "only if they have arguments",
+        line: 1
+      }
+    ]
+    assert expected_errors == errors
+  end
+
+end


### PR DESCRIPTION
I added a new rule which ensures parentheses are used when a function declaration has arguments, and not used when it doesn't have arguments. I figured that this is a good rule to have as it is listed in this Elixir Style Guide: https://github.com/niftyn8/elixir_style_guide#syntax. Let me know if I can improve my implementation in any way - I'm new to Elixir.

For example:

```elixir
# These are good:

def foo do
end

def bar(x) do
end

# These are bad:

def foo() do
end

def bar x do
end
```