### PR TITLE
New rule: MultipleBlankLines

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,1 +1,5 @@
 use Mix.Config
+
+config :dogma,
+  rule_set: Dogma.RuleSet.All,
+  override: %{ MultipleBlankLines => [ max_lines: 2 ] }

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,7 +1,7 @@
 # Dogma Rules
 
 These are the rules included in Dogma by default. Currently there are
-28 of them.
+29 of them.
 
 ## Contents
 
@@ -22,6 +22,7 @@ These are the rules included in Dogma by default. Currently there are
 * [ModuleAttributeName](#moduleattributename)
 * [ModuleDoc](#moduledoc)
 * [ModuleName](#modulename)
+* [MultipleBlankLines](#multipleblanklines)
 * [NegatedAssert](#negatedassert)
 * [NegatedIfUnless](#negatedifunless)
 * [PipelineStart](#pipelinestart)
@@ -342,6 +343,11 @@ While this is considered invalid:
 
     defmodule Hello_World do
     end
+
+
+### MultipleBlankLines
+
+A rule that disallows multiple consecutive blank lines.
 
 
 ### NegatedAssert

--- a/lib/dogma/rule/multiple_blank_lines.ex
+++ b/lib/dogma/rule/multiple_blank_lines.ex
@@ -1,0 +1,53 @@
+defmodule Dogma.Rule.MultipleBlankLines do
+  @moduledoc """
+  A rule that disallows multiple consecutive blank lines.
+  """
+
+  @behaviour Dogma.Rule
+
+  alias Dogma.Error
+
+  def test(script), do: test(script, [])
+
+  def test(script, _config = []) do
+    test(script, max_lines: 1)
+  end
+
+  def test(script, max_lines: max) do
+    script.lines |> strip_lines |> check_blank_lines(max)
+  end
+
+  defp strip_lines(lines) do
+    Enum.map lines, fn {line, text} ->
+      {line, String.strip(text)}
+    end
+  end
+
+  defp check_blank_lines(lines, max, blank_count \\ 0, acc \\ [])
+
+  defp check_blank_lines([], _max, _blank_count, acc) do
+    Enum.reverse(acc)
+  end
+
+  defp check_blank_lines([{_, ""} | rest], max, blank_count, acc) do
+    check_blank_lines(rest, max, blank_count + 1, acc)
+  end
+
+  defp check_blank_lines([{line, _} | rest], max, blank_count, acc)
+  when blank_count > max do
+    check_blank_lines(rest, max, 0, [error(line - 1) | acc])
+  end
+
+  defp check_blank_lines([_ | rest], max, _blank_count, acc) do
+    check_blank_lines(rest, max, 0, acc)
+  end
+
+  defp error(line) do
+    %Error{
+      rule:    __MODULE__,
+      message: "Multiple consecutive blank lines detected.",
+      line:    line,
+    }
+  end
+
+end

--- a/lib/dogma/rule_set/all.ex
+++ b/lib/dogma/rule_set/all.ex
@@ -26,6 +26,7 @@ defmodule Dogma.RuleSet.All do
       ModuleAttributeName     => [],
       ModuleDoc               => [],
       ModuleName              => [],
+      MultipleBlankLines      => [max_lines: 1],
       NegatedAssert           => [],
       NegatedIfUnless         => [],
       PipelineStart           => [],

--- a/test/dogma/config_test.exs
+++ b/test/dogma/config_test.exs
@@ -61,8 +61,9 @@ defmodule Dogma.ConfigTest do
     end
 
     should "default to []" do
-      assert nil == Application.get_env( :dogma, :rule_set )
-      assert [] == Config.build.exclude
+      TemporaryEnv.delete( :dogma, :exclude ) do
+        assert [] == Config.build.exclude
+      end
     end
   end
 

--- a/test/dogma/rule/final_newline_test.exs
+++ b/test/dogma/rule/final_newline_test.exs
@@ -14,7 +14,6 @@ defmodule Dogma.Rule.FinalNewlineTest do
     assert [] == errors
   end
 
-
   should "error with no final newline" do
     errors = "IO.puts 1\nIO.puts 2\nIO.puts 3" |> lint
     expected_errors = [

--- a/test/dogma/rule/module_name_test.exs
+++ b/test/dogma/rule/module_name_test.exs
@@ -45,7 +45,6 @@ defmodule Dogma.Rule.ModuleNameTest do
     assert [] == errors
   end
 
-
   should "a snake_case module name" do
     errors = """
     defmodule Snake_case do
@@ -109,7 +108,6 @@ defmodule Dogma.Rule.ModuleNameTest do
     ]
     assert expected_errors == errors
   end
-
 
   should "a non-capitalised 2 part name" do
     errors = """

--- a/test/dogma/rule/multiple_blank_lines_test.exs
+++ b/test/dogma/rule/multiple_blank_lines_test.exs
@@ -1,0 +1,53 @@
+defmodule Dogma.Rule.MultipleBlankLinesTest do
+  use ShouldI
+
+  alias Dogma.Rule.MultipleBlankLines
+  alias Dogma.Script
+  alias Dogma.Error
+
+  @message "Multiple consecutive blank lines detected."
+
+  defp lint(script) do
+    script |> Script.parse!( "foo.ex" ) |> MultipleBlankLines.test
+  end
+
+  should "not error with single empty lines" do
+    errors = """
+    def foo do
+    end
+
+    defp bar do
+    end
+    """ |> lint
+    assert [] == errors
+  end
+
+  should "error with multiple empty lines" do
+    errors = """
+    def foo do
+    end
+
+
+    def bar do
+    end
+
+    \n
+    def baz do
+    end
+    """ |> lint
+    expected_errors = [
+      %Error{
+        rule: MultipleBlankLines,
+        message: @message,
+        line: 4
+      },
+      %Error{
+        rule: MultipleBlankLines,
+        message: @message,
+        line: 9
+      }
+    ]
+    assert expected_errors == errors
+  end
+
+end

--- a/test/dogma/rule/pipeline_start_test.exs
+++ b/test/dogma/rule/pipeline_start_test.exs
@@ -19,7 +19,6 @@ defmodule Dogma.Rule.PipelineStartTest do
     assert [] == errors
   end
 
-
   should "not error with a string start" do
     errors = """
     "A pie"
@@ -212,7 +211,6 @@ defmodule Dogma.Rule.PipelineStartTest do
     """ |> lint
     assert [] == errors
   end
-
 
   should "not error with a sigil start" do
     errors = """


### PR DESCRIPTION
This rule prevents multiple consecutive blank lines. I've found this type of rule useful in linters for other languages. I'm curious to see whether others agree with this rule or not in Elixir-land. 