### PR TITLE
New rule: InfixOperatorSpaces

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,7 +1,7 @@
 # Dogma Rules
 
 These are the rules included in Dogma by default. Currently there are
-28 of them.
+29 of them.
 
 ## Contents
 
@@ -14,6 +14,7 @@ These are the rules included in Dogma by default. Currently there are
 * [FunctionName](#functionname)
 * [FunctionParentheses](#functionparentheses)
 * [HardTabs](#hardtabs)
+* [InfixOperatorSpaces](#infixoperatorspaces)
 * [InterpolationOnlyString](#interpolationonlystring)
 * [LineLength](#linelength)
 * [LiteralInCondition](#literalincondition)
@@ -228,6 +229,31 @@ So the following would be invalid:
     def something do
     \t:body # this line starts with a tab, not spaces
     end
+
+
+### InfixOperatorSpaces
+
+A rule that ensures infix operators are surrounded by spaces.
+
+For example, it considers the following expressions valid:
+
+    foo = bar
+
+    foo + bar
+
+    foo <= bar
+
+    foo || bar
+
+But it considers these invalid:
+
+    foo=bar
+
+    foo+bar
+
+    foo<=bar
+
+    foo||bar
 
 
 ### InterpolationOnlyString

--- a/lib/dogma/rule/infix_operator_spaces.ex
+++ b/lib/dogma/rule/infix_operator_spaces.ex
@@ -1,0 +1,89 @@
+defmodule Dogma.Rule.InfixOperatorSpaces do
+  @moduledoc """
+  A rule that ensures infix operators are surrounded by spaces.
+
+  For example, it considers the following expressions valid:
+
+      foo = bar
+
+      foo + bar
+
+      foo <= bar
+
+      foo || bar
+
+  But it considers these invalid:
+
+      foo=bar
+
+      foo+bar
+
+      foo<=bar
+
+      foo||bar
+  """
+
+  @behaviour Dogma.Rule
+
+  alias Dogma.Error
+
+  @operators [:dual_op, :mult_op, :match_op, :rel_op, :and_op, :or_op,
+    :comp_op, :two_op, :assoc_op]
+
+  def test(script, _config = [] \\ []) do
+    script.tokens |> operator_positions |> check_infix_spaces(script.lines)
+  end
+
+  defp operator_positions(tokens, acc \\ [])
+
+  defp operator_positions([], acc) do
+    Enum.reverse(acc)
+  end
+
+  defp operator_positions([{token, position, _} | rest], acc)
+  when token in @operators do
+    operator_positions(rest, [position | acc])
+  end
+
+  defp operator_positions([_ | rest], acc) do
+    operator_positions(rest, acc)
+  end
+
+  defp check_infix_spaces(positions, lines, acc \\ [])
+
+  defp check_infix_spaces(positions, lines, acc)
+  when positions == [] or lines == [] do
+    Enum.reverse(acc)
+  end
+
+  defp check_infix_spaces(positions, lines, acc) do
+    {pline, start, finish} = hd(positions)
+    {line, text} = hd(lines)
+
+    cond do
+      pline > line ->
+        check_infix_spaces(positions, tl(lines), acc)
+      pline < line ->
+        check_infix_spaces(tl(positions), lines, acc)
+      valid_operator_spaces(text, start, finish) ->
+        check_infix_spaces(tl(positions), lines, acc)
+      true ->
+        check_infix_spaces(tl(positions), tl(lines), [error(line) | acc])
+    end
+  end
+
+  defp valid_operator_spaces(text, start, finish) do
+    char_before = String.slice(text, start - 2..start - 2)
+    char_after = String.slice(text, finish - 1..finish - 1)
+    char_before == " " && (finish > String.length(text) || char_after == " ")
+  end
+
+  defp error(line) do
+    %Error{
+      rule:    __MODULE__,
+      message: "Infix operators should be surrounded by whitespace.",
+      line:    line,
+    }
+  end
+
+end

--- a/lib/dogma/rule_set/all.ex
+++ b/lib/dogma/rule_set/all.ex
@@ -18,6 +18,7 @@ defmodule Dogma.RuleSet.All do
       FunctionName            => [],
       FunctionParentheses     => [],
       HardTabs                => [],
+      InfixOperatorSpaces     => [],
       InterpolationOnlyString => [],
       LineLength              => [max_length: 80],
       LiteralInCondition      => [],

--- a/test/dogma/rule/infix_operator_spaces_test.exs
+++ b/test/dogma/rule/infix_operator_spaces_test.exs
@@ -1,0 +1,83 @@
+defmodule Dogma.Rule.InfixOperatorSpacesTest do
+  use ShouldI
+
+  alias Dogma.Rule.InfixOperatorSpaces
+  alias Dogma.Script
+  alias Dogma.Error
+
+  defp lint(script) do
+    script |> Script.parse!( "foo.ex" ) |> InfixOperatorSpaces.test
+  end
+
+  should "not error with spaces around infix operators" do
+    errors = """
+    1 < 2 && 2 >= 3 || 4 > 7 || 3 <= 9
+    2 - 1 * 3 / 4 + 5
+    a = 1
+    b ==
+      5
+    %{:c => 1}
+    """ |> lint
+    assert [] == errors
+  end
+
+  should "not error with unary operators" do
+    errors = """
+    -1
+    b = -3
+    !c
+    """ |> lint
+    assert [] == errors
+  end
+
+  should "error without spaces before infix operators" do
+    errors = """
+    1+ 2
+    3* 4
+    1= 1
+    a<= b
+    c&& d
+    e|| f
+    g<> h
+    i== 2
+    x + y+ z
+    %{:j=> 1}
+    k==
+      1
+    """ |> lint
+    expected_errors = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] |> Enum.map fn line ->
+      %Error{
+        rule: InfixOperatorSpaces,
+        message: "Infix operators should be surrounded by whitespace.",
+        line: line
+      }
+    end
+    assert expected_errors == errors
+  end
+
+  should "error without spaces after infix operators" do
+    errors = """
+    1 +2
+    3 *4
+    1 =1
+    a <=b
+    c &&d
+    e ||f
+    g <>h
+    i ==2
+    x + y +z
+    %{:j =>1}
+    k
+      ==1
+    """ |> lint
+    expected_errors = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12] |> Enum.map fn line ->
+      %Error{
+        rule: InfixOperatorSpaces,
+        message: "Infix operators should be surrounded by whitespace.",
+        line: line
+      }
+    end
+    assert expected_errors == errors
+  end
+
+end


### PR DESCRIPTION
This is an initial idea of how to enforce that spaces are put around infix operators. It "works" by finding the lines and locations of each infix operator, then checking the characters before and after those operators to ensure that they are spaces. There's a couple problems with this approach:

1. It relies on the position information of the infix operators given in the `:tokens` list. This information is not available in Elixir 1.0.5  as far as I know.
2. For some reason, unary operators (i.e. the `-` in `a = -1`) are given the token type of `:dual_op` in the list of tokens, when it seems like they should be listed as `:unary_op`. This is currently causing the tests to fail because I can't think of an easy way for the rule to recognize that there shouldn't be a space after unary operators like this.

Any ideas on how to resolve the two issues above? Maybe there's a smarter approach entirely?