### PR TITLE
Remove weird exception.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,4 @@
 use Mix.Config
 
 config :dogma,
-  rule_set: Dogma.RuleSet.All,
-  override: %{ MultipleBlankLines => [ max_lines: 2 ] }
+  rule_set: Dogma.RuleSet.All

--- a/lib/dogma/rule_set/all.ex
+++ b/lib/dogma/rule_set/all.ex
@@ -26,7 +26,7 @@ defmodule Dogma.RuleSet.All do
       ModuleAttributeName     => [],
       ModuleDoc               => [],
       ModuleName              => [],
-      MultipleBlankLines      => [max_lines: 1],
+      MultipleBlankLines      => [max_lines: 2],
       NegatedAssert           => [],
       NegatedIfUnless         => [],
       PipelineStart           => [],


### PR DESCRIPTION
The rest of the settings in the default rule set are based on personal preference. However, Dogma sets an override to *its own rules* for the maximum number of blank lines, which doesn't make sense to me - why is this opinion not strong enough to be considered part of the default rule set?

This PR ensures the opinions of the Dogma writers are entirely in the default rule set.