### PR TITLE
Dogma should not be a production dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add Dogma to your Mix dependencies
 # mix.exs
 def deps do
   [
-    {:dogma, "~> 0.0", only: :dev},
+    {:dogma, "~> 0.0", only: [:dev, :test]},
   ]
 end
 ```


### PR DESCRIPTION
Hey there,

I noticed that the readme recommends you install Dogma only specifying that it should be run in development  - to me it seems that Dogma should also be run in the test environment also.