### PR TITLE
Fix dead link to formatters in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ It's also a code style linter for Elixir, powered by shame.
 * [Usage](#usage)
 * [Configuration][config-doc]
 * [Rules][rules-doc]
-* [Output formats][formatters-doc]
+* [Output formats][reporters-doc]
 
 [config-doc]: https://github.com/lpil/dogma/blob/master/docs/configuration.md
 [rules-doc]: https://github.com/lpil/dogma/blob/master/docs/rules.md
-[formatters-doc]: https://github.com/lpil/dogma/blob/master/docs/formatters.md
+[reporters-doc]: https://github.com/lpil/dogma/blob/master/docs/reporters.md
 
 
 ## About


### PR DESCRIPTION
Seems like #147 broke this link by renaming the file from formatters to
reporters.
I kept the link text as 'Output formats' as it seems like the CLI option
is still called format even though the module is now called reporters.