### PR TITLE
#173 Add rule for mixed tabs and spaces

### DIFF
--- a/lib/dogma/rule/hard_tabs.ex
+++ b/lib/dogma/rule/hard_tabs.ex
@@ -11,7 +11,7 @@ defmodule Dogma.Rule.HardTabs do
 
   @behaviour Dogma.Rule
 
-  @indenting_tab_pattern ~r/^\t+.+/
+  @indenting_tab_pattern ~r/^[\t\s]*\t+/
 
   alias Dogma.Error
 

--- a/test/dogma/rule/hard_tabs_test.exs
+++ b/test/dogma/rule/hard_tabs_test.exs
@@ -36,6 +36,15 @@ defmodule Dogma.Rule.HardTabsTest do
     assert [] == errors
   end
 
+  should "error when tabs are mixed with spaces" do
+    errors = """
+    def foo
+      \t:function_body
+    end
+    """ |> lint
+    assert [error_on_line(2)] == errors
+  end
+
   defp error_on_line(line) do
     %Error{
       line: Dogma.Script.line(line),


### PR DESCRIPTION
#173 Modified regular expression for HardTabs rule to detect code indented with a mixture of tabs and spaces