### PR TITLE
SpaceAfterComma rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -480,7 +480,7 @@ and breaking up multiple expressions on different lines improves readability.
 
 ### SpaceAfterComma
 
-A rule that enforces to use `spaces` after comma.
+A rule that enforces to use at least `spaces` after comma.
 
 This rule can be configured with the `spaces` option, which allows you to
 specify your own number of spaces after comma.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,7 +1,7 @@
 # Dogma Rules
 
 These are the rules included in Dogma by default. Currently there are
-31 of them.
+32 of them.
 
 ## Contents
 
@@ -30,6 +30,7 @@ These are the rules included in Dogma by default. Currently there are
 * [PredicateName](#predicatename)
 * [QuotesInString](#quotesinstring)
 * [Semicolon](#semicolon)
+* [SpaceAfterComma](#spaceaftercomma)
 * [TakenName](#takenname)
 * [TrailingBlankLines](#trailingblanklines)
 * [TrailingWhitespace](#trailingwhitespace)
@@ -475,6 +476,14 @@ For example, these are considered invalid:
 
 This is because Elixir does not require semicolons to terminate expressions,
 and breaking up multiple expressions on different lines improves readability.
+
+
+### SpaceAfterComma
+
+A rule that enforces to use `spaces` after comma.
+
+This rule can be configured with the `spaces` option, which allows you to
+specify your own number of spaces after comma.
 
 
 ### TakenName

--- a/lib/dogma/reporter/flycheck.ex
+++ b/lib/dogma/reporter/flycheck.ex
@@ -15,7 +15,7 @@ defmodule Dogma.Reporter.Flycheck do
     {:ok, []}
   end
 
-  def handle_event(_,_), do: {:ok, []}
+  def handle_event(_, _), do: {:ok, []}
 
   alias Dogma.Script
 

--- a/lib/dogma/reporter/json.ex
+++ b/lib/dogma/reporter/json.ex
@@ -41,7 +41,7 @@ defmodule Dogma.Reporter.JSON do
     {:ok, []}
   end
 
-  def handle_events(_,_), do: {:ok, []}
+  def handle_events(_, _), do: {:ok, []}
 
   @doc """
   Runs at the end of the test suite, printing json.

--- a/lib/dogma/rule/function_name.ex
+++ b/lib/dogma/rule/function_name.ex
@@ -46,7 +46,7 @@ defrule Dogma.Rule.FunctionName do
   end
 
   # If the function is named by unquoting something then we can't check it
-  defp check_function({:unquote,_,_} , _meta, node, errors) do
+  defp check_function({:unquote, _, _} , _meta, node, errors) do
     {node, errors}
   end
 

--- a/lib/dogma/rule/module_doc.ex
+++ b/lib/dogma/rule/module_doc.ex
@@ -41,7 +41,7 @@ defrule Dogma.Rule.ModuleDoc do
   end
 
   defp check_node({:defmodule, m, [mod, [do: module_body]]} = node, errors) do
-    {_,_,names} = mod
+    {_, _, names} = mod
     if module_body |> moduledoc? do
       {node, errors}
     else

--- a/lib/dogma/rule/predicate_name.ex
+++ b/lib/dogma/rule/predicate_name.ex
@@ -40,7 +40,7 @@ defrule Dogma.Rule.PredicateName do
     Regex.run(~r{\A(is|has)_(\w+)\?\Z}, line)
   end
 
-  defp test_predicate({:unquote,_,_} , _meta, node, errors) do
+  defp test_predicate({:unquote, _, _} , _meta, node, errors) do
     {node, errors}
   end
 

--- a/lib/dogma/rule/space_after_comma.ex
+++ b/lib/dogma/rule/space_after_comma.ex
@@ -11,6 +11,7 @@ defrule Dogma.Rule.SpaceAfterComma, [spaces: 1] do
 
   def test(rule, script) do
     script.lines
+    |> Enum.map(&drop_strings/1)
     |> Enum.filter(fn line -> check_line(rule, line) end)
     |> Enum.map(fn line ->  error(rule, line) end)
   end
@@ -20,14 +21,18 @@ defrule Dogma.Rule.SpaceAfterComma, [spaces: 1] do
     |> Regex.scan(line)
     |> Enum.any?(fn [_, group] ->
       String.length(group) != rule.spaces
-      end)
+    end)
+  end
+
+  defp drop_strings({pos, line}) do
+    {pos, Regex.replace(~r/\"(.*?)\"/, line, "\"\"")}
   end
 
   defp error(rule, {pos, _}) do
     %Error{
       rule:     __MODULE__,
       message:  "Should be #{rule.spaces} spaces after comma",
-      line: Dogma.Script.line(pos),
+      line:     Dogma.Script.line(pos),
     }
   end
 end

--- a/lib/dogma/rule/space_after_comma.ex
+++ b/lib/dogma/rule/space_after_comma.ex
@@ -1,0 +1,22 @@
+use Dogma.RuleBuilder
+
+defrule Dogma.Rule.SpaceAfterComma, [spaces: 1] do
+  @moduledoc """
+  A rule that enforces to use `spaces` after comma.
+
+  This rule can be configured with the `spaces` option, which allows you to
+  specify your own number of spaces after comma.
+  """
+
+  def test(rule, script) do
+    []
+  end
+
+  defp error(rule, {pos, line}) do
+    %Error{
+      rule:     __MODULE__,
+      message:  "Should be #{rule.spaces} spaces after comma",
+      line: Dogma.Script.line(pos),
+    }
+  end
+end

--- a/lib/dogma/rule/space_after_comma.ex
+++ b/lib/dogma/rule/space_after_comma.ex
@@ -2,7 +2,7 @@ use Dogma.RuleBuilder
 
 defrule Dogma.Rule.SpaceAfterComma, [spaces: 1] do
   @moduledoc """
-  A rule that enforces to use `spaces` after comma.
+  A rule that enforces to use at least `spaces` after comma.
 
   This rule can be configured with the `spaces` option, which allows you to
   specify your own number of spaces after comma.
@@ -10,8 +10,7 @@ defrule Dogma.Rule.SpaceAfterComma, [spaces: 1] do
   @spaces_pattern ~r/\,(\s*).+/
 
   def test(rule, script) do
-    script.lines
-    |> Enum.map(&drop_strings/1)
+    script.processed_lines
     |> Enum.filter(fn line -> check_line(rule, line) end)
     |> Enum.map(fn line ->  error(rule, line) end)
   end
@@ -20,12 +19,8 @@ defrule Dogma.Rule.SpaceAfterComma, [spaces: 1] do
     @spaces_pattern
     |> Regex.scan(line)
     |> Enum.any?(fn [_, group] ->
-      String.length(group) != rule.spaces
+      String.length(group) < rule.spaces
     end)
-  end
-
-  defp drop_strings({pos, line}) do
-    {pos, Regex.replace(~r/\"(.*?)\"/, line, "\"\"")}
   end
 
   defp error(rule, {pos, _}) do

--- a/lib/dogma/rule/space_after_comma.ex
+++ b/lib/dogma/rule/space_after_comma.ex
@@ -7,12 +7,23 @@ defrule Dogma.Rule.SpaceAfterComma, [spaces: 1] do
   This rule can be configured with the `spaces` option, which allows you to
   specify your own number of spaces after comma.
   """
+  @spaces_pattern ~r/\,(\s*).+/
 
   def test(rule, script) do
-    []
+    script.lines
+    |> Enum.filter(fn line -> check_line(rule, line) end)
+    |> Enum.map(fn line ->  error(rule, line) end)
   end
 
-  defp error(rule, {pos, line}) do
+  defp check_line(rule, {_, line}) do
+    @spaces_pattern
+    |> Regex.scan(line)
+    |> Enum.any?(fn [_, group] ->
+      String.length(group) != rule.spaces
+      end)
+  end
+
+  defp error(rule, {pos, _}) do
     %Error{
       rule:     __MODULE__,
       message:  "Should be #{rule.spaces} spaces after comma",

--- a/lib/dogma/rule_set/all.ex
+++ b/lib/dogma/rule_set/all.ex
@@ -35,6 +35,7 @@ defmodule Dogma.RuleSet.All do
       %Rule.PredicateName{},
       %Rule.QuotesInString{},
       %Rule.Semicolon{},
+      %Rule.SpaceAfterComma{},
       %Rule.TakenName{},
       %Rule.TrailingBlankLines{},
       %Rule.TrailingWhitespace{},

--- a/lib/dogma/util/ast_node.ex
+++ b/lib/dogma/util/ast_node.ex
@@ -22,13 +22,13 @@ defmodule Dogma.Util.AST do
   def literal?(x) when is_boolean(x), do: true
   def literal?(x) when is_list(x), do: true
   def literal?(x) when is_number(x), do: true
-  def literal?({_,_}), do: true
+  def literal?({_, _}), do: true
   def literal?({:{}, _, _}), do: true
   def literal?({:%{}, _, _}), do: true
 
   for char <- sigil_chars do
     sigil_atom = String.to_atom("sigil_" <> char)
-    def literal?({unquote(sigil_atom),_,_}), do: true
+    def literal?({unquote(sigil_atom), _, _}), do: true
   end
   def literal?(_), do: false
 end

--- a/test/dogma/rule/space_after_comma_test.exs
+++ b/test/dogma/rule/space_after_comma_test.exs
@@ -52,6 +52,22 @@ defmodule Dogma.Rule.SpaceAfterCommaTest do
     assert [] == errors
   end
 
+  should "ignore comma in strings" do
+    errors = """
+    v = "should,be,tottaly ignored"
+    """ |> lint
+    assert [] == errors
+  end
+
+  should "not check strings" do
+    errors = """
+    def foo do
+      ["1,", "2", "3\",\""]
+    end
+    """ |> lint
+    assert [] == errors
+  end
+
   defp error_on_line(line, spaces) do
     %Error{
       line: Dogma.Script.line(line),

--- a/test/dogma/rule/space_after_comma_test.exs
+++ b/test/dogma/rule/space_after_comma_test.exs
@@ -1,31 +1,55 @@
-defmodule Dogma.Rule.SpaceAfterComma do
+defmodule Dogma.Rule.SpaceAfterCommaTest do
   use RuleCase, for: SpaceAfterComma
 
+  defp lint(script, rule) do
+    script |> Script.parse!( "" ) |> fn s -> Rule.test(rule, s) end.()
+  end
+  defp lint(script) do
+    lint script, @rule
+  end
+
   should "allow default number of spaces after comma" do
-    script = """
+    errors = """
     def foo do
       [1, 2, 3]
     end
-    """ |> Script.parse!("")
-    assert [] == Rule.test( @rule, script )
+    """ |> lint
+    assert [] == errors
   end
 
   should "error when style violation" do
-    script = """
+    errors = """
     def foo do
       [1,  2,   3]
     end
-    """ |> Script.parse!("")
-    expected_errors = [ error_on_line(2, 1)]
-    assert expected_errors == Rule.test( @rule, script )
+    """ |> lint
+    assert errors == [error_on_line(2, 1)]
   end
 
-  should "allow to change default option." do
-    rule   = %SpaceAfterComma{ spaces: 100 }
-    script = """
+  should "allow to change default option" do
+    rule   = %SpaceAfterComma{ spaces: 2 }
+    errors = """
     alias Math.List,  as: List
-    """ |> Script.parse!("")
-    assert [] == Rule.test( rule, script )
+    """ |> lint(rule)
+    assert [] == errors
+  end
+
+  should "allow 0 spaces after comma" do
+    rule   = %SpaceAfterComma{ spaces: 0 }
+    errors = """
+    alias Math.List,as: List
+    """ |> lint(rule)
+    assert [] == errors
+  end
+
+  should "allow no spaces on newline" do
+    errors = """
+    %{
+      rule:    '__MODULE__',
+      message: "Houston we have a problem",
+    }
+    """ |> lint
+    assert [] == errors
   end
 
   defp error_on_line(line, spaces) do

--- a/test/dogma/rule/space_after_comma_test.exs
+++ b/test/dogma/rule/space_after_comma_test.exs
@@ -1,0 +1,38 @@
+defmodule Dogma.Rule.SpaceAfterComma do
+  use RuleCase, for: SpaceAfterComma
+
+  should "allow default number of spaces after comma" do
+    script = """
+    def foo do
+      [1, 2, 3]
+    end
+    """ |> Script.parse!("")
+    assert [] == Rule.test( @rule, script )
+  end
+
+  should "error when style violation" do
+    script = """
+    def foo do
+      [1,  2,   3]
+    end
+    """ |> Script.parse!("")
+    expected_errors = [ error_on_line(2, 1)]
+    assert expected_errors == Rule.test( @rule, script )
+  end
+
+  should "allow to change default option." do
+    rule   = %SpaceAfterComma{ spaces: 100 }
+    script = """
+    alias Math.List,  as: List
+    """ |> Script.parse!("")
+    assert [] == Rule.test( rule, script )
+  end
+
+  defp error_on_line(line, spaces) do
+    %Error{
+      line: Dogma.Script.line(line),
+      message: "Should be #{spaces} spaces after comma",
+      rule: SpaceAfterComma
+    }
+  end
+end

--- a/test/dogma/rule/space_after_comma_test.exs
+++ b/test/dogma/rule/space_after_comma_test.exs
@@ -1,78 +1,71 @@
 defmodule Dogma.Rule.SpaceAfterCommaTest do
   use RuleCase, for: SpaceAfterComma
 
-  defp lint(script, rule) do
-    script |> Script.parse!( "" ) |> fn s -> Rule.test(rule, s) end.()
-  end
-  defp lint(script) do
-    lint script, @rule
-  end
-
-  should "allow default number of spaces after comma" do
-    errors = """
+  should "allow at least 1 spaces after comma" do
+    script = """
     def foo do
-      [1, 2, 3]
+      [1, 2, 3,  4]
     end
-    """ |> lint
-    assert [] == errors
+    """ |> Script.parse!("")
+    assert [] == Rule.test( @rule, script )
   end
 
   should "error when style violation" do
-    errors = """
+    script = """
     def foo do
-      [1,  2,   3]
+      [1,2, 3]
     end
-    """ |> lint
-    assert errors == [error_on_line(2, 1)]
+    """ |> Script.parse!("")
+    assert [error_on_line(2, 1)] == Rule.test( @rule, script )
   end
 
   should "allow to change default option" do
     rule   = %SpaceAfterComma{ spaces: 2 }
-    errors = """
+    script = """
     alias Math.List,  as: List
-    """ |> lint(rule)
-    assert [] == errors
+    """ |> Script.parse!("")
+    assert [] == Rule.test( rule, script )
   end
 
   should "allow 0 spaces after comma" do
     rule   = %SpaceAfterComma{ spaces: 0 }
-    errors = """
+    script = """
     alias Math.List,as: List
-    """ |> lint(rule)
-    assert [] == errors
+    """ |> Script.parse!("")
+    assert [] == Rule.test( rule, script )
   end
 
   should "allow no spaces on newline" do
-    errors = """
+    script = """
     %{
       rule:    '__MODULE__',
       message: "Houston we have a problem",
     }
-    """ |> lint
-    assert [] == errors
+    """ |> Script.parse!("")
+    assert [] == Rule.test( @rule, script )
   end
 
   should "ignore comma in strings" do
-    errors = """
+    script = """
     v = "should,be,tottaly ignored"
-    """ |> lint
-    assert [] == errors
+    """ |> Script.parse!("")
+    assert [] == Rule.test( @rule, script )
   end
 
   should "not check strings" do
-    errors = """
+    script = """
     def foo do
       ["1,", "2", "3\",\""]
     end
-    """ |> lint
-    assert [] == errors
+    """ |> Script.parse!("")
+    assert [] == Rule.test( @rule, script )
   end
 
   defp error_on_line(line, spaces) do
     %Error{
-      line: Dogma.Script.line(line),
+      line:    Dogma.Script.line(line),
       message: "Should be #{spaces} spaces after comma",
-      rule: SpaceAfterComma
+      rule:    SpaceAfterComma
     }
   end
 end

--- a/test/dogma/rule/variable_name_test.exs
+++ b/test/dogma/rule/variable_name_test.exs
@@ -96,7 +96,7 @@ defmodule Dogma.Rule.VariableNameTest do
         rule:     VariableName,
         message:  "Variable names should be in snake_case",
         line: 1,
-      },]
+      }]
     assert expected_errors == Rule.test( @rule, script )
   end
 

--- a/test/dogma/util/ast_node_test.exs
+++ b/test/dogma/util/ast_node_test.exs
@@ -37,7 +37,7 @@ defmodule Dogma.Util.ASTTest do
     end
 
     should "be true for tuples with two elements" do
-      tuple = quote do: {4,5}
+      tuple = quote do: {4, 5}
       assert AST.literal?(tuple)
     end
 


### PR DESCRIPTION
#146 That's a really straightforward implementation. However there are 39 errors! for this rule in the project. Some of those are really easy to fix but there are couple places where spaces after comma used for some kind of visual indent like

```elixir
  defp elixirc_paths(:test), do: ["lib", "test/support"]
  defp elixirc_paths(_),     do: ["lib"]
```

What should we do with such corner cases?
