### PR TITLE
add support for config/dogma.exs file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,10 +5,13 @@ Dogma can be configured to have different behaviours via your project's Mix
 config. You can select a rule set to use as your base configuration, and then
 apply additional configuration on top of the set.
 
+Dogma will load the config from `config/dogma.exs` if it exists.
+
 Here's an example configuration.
 
 ```elixir
-# config/config.exs
+# config/dogma.exs
+use Mix.Config
 alias Dogma.Rule
 
 config :dogma,

--- a/lib/mix/tasks/dogma.ex
+++ b/lib/mix/tasks/dogma.ex
@@ -7,8 +7,13 @@ defmodule Mix.Tasks.Dogma do
   alias Dogma.Config
   alias Dogma.Reporters
 
+  @config_file_path "config/dogma.exs"
+
   def run(argv) do
     {dir, reporter, noerror} = argv |> parse_args
+    if File.regular?(@config_file_path) do
+      Mix.Tasks.Loadconfig.run([ @config_file_path])
+    end
     config = Config.build
 
     {:ok, dispatcher} = GenEvent.start_link([])


### PR DESCRIPTION
When running `mix dogma` with a custom configuration for a rule,
`config.exs` is loaded in mix before dogma's rules are expended so mix
failes with: `config/config.exs:45: Dogma.Rule.LineLength.struct/0 is
undefined, cannot expand struct Dogma.Rule.LineLength` (see
lpil/dogma#183)

This commit allows to put the dogma configuration in `config/dogma.exs`
which is loaded in the beginning of the `mix dogma` task, at this time
the rules are already defined