### PR TITLE
fixes rules are running even when `enabled: false` is set in the config

### DIFF
--- a/lib/dogma/runner.ex
+++ b/lib/dogma/runner.ex
@@ -7,6 +7,7 @@ defmodule Dogma.Runner do
 
   def run_tests(script, rules) when is_map(script) and is_list(rules) do
     rules
+    |> Enum.filter(&(&1.enabled))
     |> Enum.map( &Rule.test(&1, script) )
     |> List.flatten
   end


### PR DESCRIPTION
Before this PR, rules are checked even if they are marked as `enabled: false` in the config.

for example:
```elixir
#config/dogma.exs
use Mix.Config
alias Dogma.Rule

config :dogma,
  rule_set: Dogma.RuleSet.All,
  exclude: [ ],
  override: [
    %Rule.ModuleDoc{ enabled: false },
  ]
```
will still show errors about modules without `@moduledoc`