### PR TITLE
Read config from config/dogma.exs if not found then try ~/.dogma.exs

### DIFF
--- a/lib/mix/tasks/dogma.ex
+++ b/lib/mix/tasks/dogma.ex
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.Dogma do
   alias Dogma.Config
   alias Dogma.Reporters
 
-  #loads a config file with fallback chain. First found will be loaded.
+  # loads a config file with fallback chain. First found will be loaded.
   @config_file_paths ["config/dogma.exs", "~/.dogma.exs"]
 
   def run(argv) do

--- a/lib/mix/tasks/dogma.ex
+++ b/lib/mix/tasks/dogma.ex
@@ -7,13 +7,12 @@ defmodule Mix.Tasks.Dogma do
   alias Dogma.Config
   alias Dogma.Reporters
 
-  @config_file_path "config/dogma.exs"
+  #loads a config file with fallback chain. First found will be loaded.
+  @config_file_paths ["config/dogma.exs", "~/.dogma.exs"]
 
   def run(argv) do
     {dir, reporter, noerror} = argv |> parse_args
-    if File.regular?(@config_file_path) do
-      Mix.Tasks.Loadconfig.run([ @config_file_path])
-    end
+    load_config_file(@config_file_paths)
     config = Config.build
 
     {:ok, dispatcher} = GenEvent.start_link([])
@@ -47,5 +46,14 @@ defmodule Mix.Tasks.Dogma do
   defp any_errors?(scripts) do
     scripts
     |> Enum.any?( &Enum.any?( &1.errors ) )
+  end
+
+
+  defp load_config_file([]), do: nil
+  defp load_config_file([path|paths]) do
+    case path |> Path.expand |> File.exists? do
+      true  -> Mix.Tasks.Loadconfig.run([path])
+      _     -> load_config_file(paths)
+    end
   end
 end


### PR DESCRIPTION
(This is a recreate from a previous pull request, but now properly scoped in its own branch)

It will now look if it can find config/dogma.exs in the project,
if not it will check if it can find ~/.dogma.exs. otherwise use the defaults

In this way a projects dogma config will always override the user config.

As this is file based, I'm not sure how to write a test for it
I did test this manually though using all four options being :

No config file at all
A config in config/dogma.exs
A config in ~/.dogma.exs
A config in config/dogma.exs and ~/.dogma.exs where the one in config wins over the home dir one
Hope you'll find this useful :)
