### PR TITLE
fixed parsing of utf8 characters

### DIFF
--- a/lib/dogma/util/script_sigils.ex
+++ b/lib/dogma/util/script_sigils.ex
@@ -38,7 +38,7 @@ defmodule Dogma.Util.ScriptSigils do
     end
   end
   defp parse_code(<< h::utf8, t::binary >>, acc) do
-    parse_code(t, acc <> <<h>>)
+    parse_code(t, acc <> <<h::utf8>>)
   end
 
   for {_open, close} <- sigils do

--- a/test/dogma/util/script_sigils_test.exs
+++ b/test/dogma/util/script_sigils_test.exs
@@ -124,5 +124,16 @@ defmodule Dogma.Util.ScriptSigilsTest do
       """
       assert desired == script |> ScriptSigils.strip
     end
+
+    should "handle utf8 characters" do
+      desired = """
+      defmodule Foo do
+        def foo do
+          "Ó"
+        end
+      end
+      """
+      assert desired == desired |> ScriptSigils.strip
+    end
   end
 end


### PR DESCRIPTION
Fixed the utf8 crashes when a source file contained non ascii characters like : "Ó"
This fixes issue https://github.com/lpil/dogma/issues/195
