### PR TITLE
New rule: InfixOperatorPadding

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,7 +1,7 @@
 # Dogma Rules
 
 These are the rules included in Dogma by default. Currently there are
-32 of them.
+33 of them.
 
 ## Contents
 
@@ -15,6 +15,7 @@ These are the rules included in Dogma by default. Currently there are
 * [FunctionName](#functionname)
 * [FunctionParentheses](#functionparentheses)
 * [HardTabs](#hardtabs)
+* [InfixOperatorPadding](#infixoperatorpadding)
 * [InterpolationOnlyString](#interpolationonlystring)
 * [LineLength](#linelength)
 * [LiteralInCondition](#literalincondition)
@@ -248,6 +249,40 @@ So the following would be invalid:
     def something do
     \t:body # this line starts with a tab, not spaces
     end
+
+
+### InfixOperatorPadding
+
+A rule that ensures that all infix operators, except the range operator `..`,
+are surrounded by spaces.
+
+This rule is only enabled for Elixir v1.1 or greater.
+
+Good:
+
+    foo = bar
+
+    foo - bar
+
+    foo || bar
+
+    foo |> bar
+
+    foo..bar
+
+Bad:
+
+    foo=bar
+
+    foo-bar
+
+    foo||bar
+
+    foo|>bar
+
+By default, no space is required between the `fn` and `->` of an anonymous
+function. A space can be required by setting the `fn_arrow_padding` option to
+`true`.
 
 
 ### InterpolationOnlyString

--- a/lib/dogma/rule/function_name.ex
+++ b/lib/dogma/rule/function_name.ex
@@ -35,10 +35,10 @@ defrule Dogma.Rule.FunctionName do
   end
 
 
-  defp check_node({:def, _, [{name, meta, _}|_]} = node, errors) do
+  defp check_node({:def, _, [{name, meta, _} | _]} = node, errors) do
     check_function(name, meta, node, errors)
   end
-  defp check_node({:defp, _, [{name, meta, _}|_]} = node, errors) do
+  defp check_node({:defp, _, [{name, meta, _} | _]} = node, errors) do
     check_function(name, meta, node, errors)
   end
   defp check_node(node, errors) do

--- a/lib/dogma/rule/infix_operator_padding.ex
+++ b/lib/dogma/rule/infix_operator_padding.ex
@@ -1,0 +1,156 @@
+use Dogma.RuleBuilder
+
+defrule Dogma.Rule.InfixOperatorPadding,
+  [fn_arrow_padding: false, elixir: ">= 1.1.0"] do
+  @moduledoc """
+  A rule that ensures that all infix operators, except the range operator `..`,
+  are surrounded by spaces.
+
+  This rule is only enabled for Elixir v1.1 or greater.
+
+  Good:
+
+      foo = bar
+
+      foo - bar
+
+      foo || bar
+
+      foo |> bar
+
+      foo..bar
+
+  Bad:
+
+      foo=bar
+
+      foo-bar
+
+      foo||bar
+
+      foo|>bar
+
+  By default, no space is required between the `fn` and `->` of an anonymous
+  function. A space can be required by setting the `fn_arrow_padding` option to
+  `true`.
+  """
+
+  @operators [
+    :comp_op,
+    :comp_op2,
+    :dual_op,
+    :mult_op,
+    :two_op,
+    :arrow_op,
+    :rel_op,
+    :rel_op2,
+    :and_op,
+    :or_op,
+    :match_op,
+    :in_match_op,
+    :assoc_op,
+    :stab_op,
+    :pipe_op
+  ]
+
+  @subtracters [
+    :number,
+    :identifier,
+    :")",
+    :")"
+  ]
+
+  @ignore_ops [
+    :-,
+    :..
+  ]
+
+  def test(rule, script) do
+    script.tokens
+    |> Enum.map(&normalize_token/1)
+    |> check_operators(rule)
+  end
+
+  defp normalize_token({a, {b, c, d}}), do: {a, b, c, d, nil}
+  defp normalize_token({a, {b, c, d}, e}), do: {a, b, c, d, e}
+  defp normalize_token({a, {b, c, d}, e, _}), do: {a, b, c, d, e}
+  defp normalize_token({a, {b, c, d}, e, _, _}), do: {a, b, c, d, e}
+
+  defp check_operators(tokens, rule, acc \\ [])
+
+  defp check_operators([], _rule, acc), do: Enum.reverse(acc)
+
+  defp check_operators([
+    {token, line, _, _, _},
+    {:identifier, line, _, _, _},
+    {:mult_op, line, _, _, :/}
+    | rest], rule, acc)
+  when token == :capture_op or token == :. do
+    check_operators(rest, rule, acc)
+  end
+
+  defp check_operators([
+    {token1, line, _, column, _},
+    {:dual_op, line, column, _, :-},
+    {token3, line, _, _, _}
+    | rest], rule, acc)
+  when (token1 in @subtracters or token1 == :")")
+  and (token3 in @subtracters or token3 == :"(") do
+    check_operators(rest, rule, [error(line) | acc])
+  end
+
+  defp check_operators([
+    {token1, line, _, _, _},
+    {:dual_op, line, _, column, :-},
+    {token3, line, column, _, _}
+    | rest], rule, acc)
+  when (token1 in @subtracters or token1 == :")")
+  and (token3 in @subtracters or token3 == :"(") do
+    check_operators(rest, rule, [error(line) | acc])
+  end
+
+  defp check_operators([
+    {:fn, line, _, column, _},
+    {:stab_op, line, column, _, _}
+    | rest], rule, acc) do
+
+    if rule.fn_arrow_padding do
+      check_operators(rest, rule, [error(line) | acc])
+    else
+      check_operators(rest, rule, acc)
+    end
+  end
+
+  for operator <- @operators do
+    defp check_operators([
+      {unquote(operator), line, _, column, value},
+      {token2, line, column, _, _}
+      | rest], rule, acc)
+    when not value in @ignore_ops and token2 != :eol do
+      check_operators(rest, rule, [error(line) | acc])
+    end
+  end
+
+  for operator <- @operators do
+    defp check_operators([
+      {_, line, _, column, _},
+      {unquote(operator), line, column, _, value}
+      | rest], rule, acc)
+    when not value in @ignore_ops do
+      check_operators(rest, rule, [error(line) | acc])
+    end
+  end
+
+  defp check_operators([_ | rest], rule, acc) do
+    check_operators(rest, rule, acc)
+  end
+
+  defp error(line) do
+    %Error{
+      rule:    __MODULE__,
+      message: "Infix operators should be surrounded by whitespace.",
+      line:    line,
+    }
+  end
+
+end

--- a/lib/dogma/rule/predicate_name.ex
+++ b/lib/dogma/rule/predicate_name.ex
@@ -26,10 +26,10 @@ defrule Dogma.Rule.PredicateName do
     script |> Script.walk( &check_node(&1, &2) )
   end
 
-  defp check_node({:def, _, [{name, meta, _}|_]} = node, errors) do
+  defp check_node({:def, _, [{name, meta, _} | _]} = node, errors) do
     test_predicate(name, meta, node, errors)
   end
-  defp check_node({:defp, _, [{name, meta, _}|_]} = node, errors) do
+  defp check_node({:defp, _, [{name, meta, _} | _]} = node, errors) do
     test_predicate(name, meta, node, errors)
   end
   defp check_node(node, errors) do

--- a/lib/dogma/rule/taken_name.ex
+++ b/lib/dogma/rule/taken_name.ex
@@ -47,13 +47,13 @@ defrule Dogma.Rule.TakenName do
     script |> Script.walk( &check_node(&1, &2) )
   end
 
-  defp check_node({:def, _, [{name, meta, _}|_]} = node, errors) do
+  defp check_node({:def, _, [{name, meta, _} | _]} = node, errors) do
     check_name(name, meta, node, errors)
   end
-  defp check_node({:defmacro, _, [{name, meta, _}|_]} = node, errors) do
+  defp check_node({:defmacro, _, [{name, meta, _} | _]} = node, errors) do
     check_name(name, meta, node, errors)
   end
-  defp check_node({:defp, _, [{name, meta, _}|_]} = node, errors) do
+  defp check_node({:defp, _, [{name, meta, _} | _]} = node, errors) do
     check_name(name, meta, node, errors)
   end
   defp check_node(node, errors) do

--- a/lib/dogma/rule_set/all.ex
+++ b/lib/dogma/rule_set/all.ex
@@ -20,6 +20,7 @@ defmodule Dogma.RuleSet.All do
       %Rule.FunctionName{},
       %Rule.FunctionParentheses{},
       %Rule.HardTabs{},
+      %Rule.InfixOperatorPadding{},
       %Rule.InterpolationOnlyString{},
       %Rule.LineLength{},
       %Rule.LiteralInCondition{},

--- a/test/dogma/config_test.exs
+++ b/test/dogma/config_test.exs
@@ -25,7 +25,13 @@ defmodule Dogma.ConfigTest do
     TemporaryEnv.delete( :dogma, :rule_set ) do
       TemporaryEnv.delete( :dogma, :override ) do
 
-        assert Dogma.RuleSet.All.rules == Config.build.rules
+        all_rules =
+          Dogma.RuleSet.All.rules
+          |> Enum.filter(fn rule ->
+            Version.match?(System.version, rule.elixir)
+          end)
+
+        assert Enum.sort(all_rules) == Enum.sort(Config.build.rules)
 
       end
     end

--- a/test/dogma/rule/infix_operator_padding_test.exs
+++ b/test/dogma/rule/infix_operator_padding_test.exs
@@ -1,0 +1,151 @@
+defmodule Dogma.Rule.InfixOperatorPaddingTest do
+  use RuleCase, for: InfixOperatorPadding
+
+  defp infix_error(line) do
+    %Error{
+      rule: InfixOperatorPadding,
+      message: "Infix operators should be surrounded by whitespace.",
+      line: line
+    }
+  end
+
+  if Version.match?(System.version, @rule.elixir) do
+
+    test "does not error with padding around infix operators" do
+      script = """
+      1 + 2 - 2 * 4 = 1 / 2 || 3 < 6 >= 2 <= 1 && false
+      2 - (-3 - 4) - 2
+      a - 1
+      a - b
+      g <> h
+      1 == 2
+      [1 / 2]
+      %{:j => 1}
+      1 &&& 2
+      j |> thing
+      cond do true -> false end
+      ^x = 1
+      """ |> Script.parse!("")
+
+      assert [] == Rule.test(@rule, script)
+    end
+
+    test "does not error with unary operators" do
+      script = """
+      -1
+      b = -3
+        -3
+      !c
+      add(-1, -5)
+      foo -10, -1
+      """ |> Script.parse!("")
+
+      assert [] == Rule.test(@rule, script)
+    end
+
+    test "does not error with function arity" do
+      script = """
+      &length/1
+      &Task.await/1
+      &Dogma.Task.Thing.work/2
+      """ |> Script.parse!("")
+
+      assert [] == Rule.test(@rule, script)
+    end
+
+    test "does not error with a multi-line match" do
+      script = """
+      a =
+        1
+      """ |> Script.parse!("")
+
+      assert [] == Rule.test(@rule, script)
+    end
+
+    test "does not error with range operator" do
+      script = """
+      1..200
+      foo..bar
+      """ |> Script.parse!("")
+
+      assert [] == Rule.test(@rule, script)
+    end
+
+    test "errors without padding before infix operators" do
+      script = """
+      1+ 2
+      2- 1
+      3* 4
+      1= 1
+      a<= b
+      c&& d
+      e|| f
+      g<> h
+      i== 2
+      [1/ 2]
+      x + y+ z
+      2- (-3 - 4)
+      (-3 - 4)- 2
+      %{:j=> 1}
+      k== 1
+      j|> thing
+      cond do true-> false end
+      1&&& 2
+      """ |> Script.parse!("")
+
+      expected_errors =
+        script.lines
+        |> Enum.map(fn {line, _} -> line end)
+        |> Enum.map(&infix_error/1)
+      assert expected_errors == Rule.test(@rule, script)
+    end
+
+    test "errors without padding after infix operators" do
+      script = """
+      1 +2
+      2 -1
+      3 *4
+      1 =1
+      a <=b
+      c &&d
+      e ||f
+      g <>h
+      i ==2
+      [1 /2]
+      x + y +z
+      2 -(-3 - 4)
+      (-3 - 4) -2
+      %{:j =>1}
+      k ==1
+      j |>thing
+      cond do true ->false end
+      1 &&&2
+      """ |> Script.parse!("")
+
+      expected_errors =
+        script.lines
+        |> Enum.map(fn {line, _} -> line end)
+        |> Enum.map(&infix_error/1)
+      assert expected_errors == Rule.test(@rule, script)
+    end
+
+    test "allows fn-> by default" do
+      script = """
+      fn-> something end
+      """ |> Script.parse!("")
+
+      assert [] == Rule.test(@rule, script)
+    end
+
+    test "disallows fn-> by configuration" do
+      rule = %InfixOperatorPadding{fn_arrow_padding: true}
+      script = """
+      fn-> something end
+      """ |> Script.parse!("")
+
+      assert [infix_error(1)] == Rule.test(rule, script)
+    end
+
+  end
+
+end

--- a/test/dogma/runner_test.exs
+++ b/test/dogma/runner_test.exs
@@ -5,12 +5,13 @@ defmodule Dogma.RunnerTest do
   alias Dogma.RuleSet.All
   alias Dogma.Runner
   alias Dogma.Script
+  alias Dogma.Config
 
   test "run_tests/2 run the given rules" do
     errors =
       "1 + 1\n"
       |> Script.parse!("foo.ex")
-      |> Runner.run_tests(All.rules)
+      |> Runner.run_tests(Config.build.rules)
     assert [] == errors
   end
 


### PR DESCRIPTION
Related to #165.

I think I finally got a solid implementation for this rule. It checks for padding around all infix operators, but handles `-` and `/` specially to allow things like `a = -1` and `&Thing.run/2`.

There's no way to get this rule working for versions of Elixir less than 1.1, because column information is not provided by the tokenizer. I still think this rule should be included in Dogma, so I've disabled it from running if the version is less than 1.1. If there is a cleaner way to disable this rule for certain versions that fits more in line with Dogma's rule configs, let me know.
