### PR TITLE
Fix typo in function clause in json reporter

### DIFF
--- a/lib/dogma/reporter/json.ex
+++ b/lib/dogma/reporter/json.ex
@@ -41,7 +41,7 @@ defmodule Dogma.Reporter.JSON do
     {:ok, []}
   end
 
-  def handle_events(_, _), do: {:ok, []}
+  def handle_event(_, _), do: {:ok, []}
 
   @doc """
   Runs at the end of the test suite, printing json.

--- a/test/dogma/reporter/json_test.exs
+++ b/test/dogma/reporter/json_test.exs
@@ -14,7 +14,14 @@ defmodule Dogma.Reporter.JSONTest do
         %Script{ path: "bar.ex", errors: [] }
       ]
 
-      result = capture_io(fn-> JSON.handle_event({:finished,  scripts}, []) end)
+      for script <- scripts do
+        _ = capture_io(fn ->
+          {:ok, []} = JSON.handle_event({:script_tested,  script}, [])
+        end)
+      end
+      result = capture_io(fn ->
+        {:ok, []} = JSON.handle_event({:finished,  scripts}, [])
+      end)
       json = Poison.decode!(result)
 
       test_system_info(json)


### PR DESCRIPTION
This error was causing the json reporter to not work at all.
Unfortunately this wasn't caught by the tests so this commit
includes a small change to the tests that make sure this won't
happen again.