### PR TITLE
Add minimum_version option

### DIFF
--- a/lib/dogma/config.ex
+++ b/lib/dogma/config.ex
@@ -23,7 +23,10 @@ defmodule Dogma.Config do
   end
 
   defp get_rules do
-    rules     = Application.get_env( :dogma, :rule_set, @default_set ).rules
+    rules =
+      Application.get_env( :dogma, :rule_set, @default_set ).rules
+      |> Enum.filter(fn rule -> Version.match?(System.version, rule.elixir) end)
+
     overrides = Application.get_env( :dogma, :override, %{} )
     rules_map = Enum.reduce( rules, %{}, &insert_rule/2 )
     overrides

--- a/lib/dogma/rule_builder.ex
+++ b/lib/dogma/rule_builder.ex
@@ -41,6 +41,8 @@ defmodule Dogma.RuleBuilder do
 
   defmacro defrule(name, opts, [do: module_ast]) when is_list(opts) do
     opts = [{:enabled, true} | opts]
+    opts = Keyword.put_new(opts, :elixir, ">= 1.0.0")
+
     quote do
       defmodule unquote(name) do
         alias Dogma.Error

--- a/test/dogma/config_test.exs
+++ b/test/dogma/config_test.exs
@@ -1,11 +1,13 @@
 defmodule Dogma.ConfigTest do
   use ExUnit.Case, async: false
   use TemporaryEnv
+  use Dogma.RuleBuilder
 
   alias Dogma.Config
   alias Dogma.Rule
 
   @dummy_set Module.concat [__MODULE__, RuleSet]
+  @version_ten_set Module.concat [__MODULE__, VersionTenRuleSet]
 
   test "rule set is taken from the application env" do
     TemporaryEnv.set( :dogma, rule_set: @dummy_set ) do
@@ -24,6 +26,16 @@ defmodule Dogma.ConfigTest do
       TemporaryEnv.delete( :dogma, :override ) do
 
         assert Dogma.RuleSet.All.rules == Config.build.rules
+
+      end
+    end
+  end
+
+  test "rule set excludes rules when the minimum version is not met" do
+    TemporaryEnv.set( :dogma, rule_set: @version_ten_set ) do
+      TemporaryEnv.delete( :dogma, :override ) do
+
+        assert Config.build.rules == []
 
       end
     end
@@ -111,4 +123,19 @@ defmodule Dogma.ConfigTest do
       ]
     end
   end
+
+  defrule VersionTen, [elixir: ">= 10.0.0"] do
+    @moduledoc false
+    def test(_rule, _script), do: []
+  end
+
+  defmodule VersionTenRuleSet do
+    @behaviour Dogma.RuleSet
+    def rules do
+      [
+        %VersionTen{}
+      ]
+    end
+  end
+
 end

--- a/test/dogma/rule_builder_test.exs
+++ b/test/dogma/rule_builder_test.exs
@@ -18,7 +18,11 @@ defmodule Dogma.RuleBuilderTest do
   end
 
   test "it sets :enabled to true" do
-    assert true = %MagicTestRule{}.enabled
+    assert %MagicTestRule{}.enabled
+  end
+
+  test "it sets :elixir to 1.0.0" do
+    assert %MagicTestRule{}.elixir == ">= 1.0.0"
   end
 
   test "it includes the args in the struct" do


### PR DESCRIPTION
Adds the ability to specify a minimum version of Elixir for a rule. The minimum version defaults to `>= 1.0.0`. 

Example:

```elixir
defrule Dogma.Rule.LineLength, [max_length: 80, elixir: ">= 1.1.0"] do
  # ...
end
```

@lpil @rrrene I threw this together, was this sort of what you had in mind based on your comments from #212?