### PR TITLE
Fix argument error

### DIFF
--- a/lib/dogma/rule/function_arity.ex
+++ b/lib/dogma/rule/function_arity.ex
@@ -24,6 +24,9 @@ defrule Dogma.Rule.FunctionArity, max: 4 do
 
   @defs ~w(def defp defmacro)a
   for type <- @defs do
+    defp check_node({unquote(type), _, nil} = node, errors, _) do
+      {node, errors}
+    end
 
     defp check_node({unquote(type), _, _} = node, errors, max) do
       {name, line, args} = get_fun_details(node)

--- a/test/dogma/rule/function_arity_test.exs
+++ b/test/dogma/rule/function_arity_test.exs
@@ -69,4 +69,15 @@ defmodule Dogma.Rule.FunctionArityTest do
     rule = %{ @rule | max: 2 }
     assert expected_errors == Rule.test( rule, script )
   end
+
+  should "only report functions and not variables" do
+    script = """
+    def testing do
+      def = ""
+      defp = ""
+      defmacro = ""
+    end
+    """ |> Script.parse!("")
+    assert [] == Rule.test(@rule, script)
+  end
 end


### PR DESCRIPTION
This happens when a variable is defined that is called `def`, `defp` or
`defmacro`.

Closes #202