### PR TITLE
Make Dogma available as an escript executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 erl_crash.dump
 *.ez
 *.beam
+dogma
 /doc/
 /docs/all.json
 /bench/snapshots

--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ Inspecting 27 files.
 
 How handy!
 
+### Install Dogma globally
+
+In order to run dogma from any directory build the escript:
+```
+mix escript.build
+```
+
+this will create an executable that you can place in your PATH
+and invoke from anywhere.
+
 
 ## Contributor Information
 

--- a/lib/mix/tasks/dogma.ex
+++ b/lib/mix/tasks/dogma.ex
@@ -9,7 +9,9 @@ defmodule Mix.Tasks.Dogma do
 
   @config_file_path "config/dogma.exs"
 
-  def run(argv) do
+  def run(argv), do: main(argv)
+
+  def main(argv) do
     {dir, reporter, noerror} = argv |> parse_args
     if File.regular?(@config_file_path) do
       Mix.Tasks.Loadconfig.run([ @config_file_path])

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule Dogma.Mixfile do
       version: @version,
       elixir: "~> 1.0",
       elixirc_paths: elixirc_paths(Mix.env),
+      escript: [ main_module: Mix.Tasks.Dogma ],
       deps: deps,
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,


### PR DESCRIPTION
This adds support for creating an escript executable that can be make available globally, rather
than on a per-project basis. This is necessary in order for flycheck integration to work properly, among other things. See https://github.com/flycheck/flycheck/pull/969 for more info.