### PR TITLE
Add mix app to `applications` in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Dogma.Mixfile do
 
   def application do
     [
-      applications: []
+      applications: [:mix]
     ]
   end
 


### PR DESCRIPTION
This fixes a bug where Mix.Tasks.Loadconfig is not available
when running from the escript executable.