### PR TITLE
Allow multiple '#' characters before a comment

### DIFF
--- a/lib/dogma/util/comment.ex
+++ b/lib/dogma/util/comment.ex
@@ -20,7 +20,7 @@ defmodule Dogma.Util.Comment do
   end
 
   def get_comment( {n, content}, acc ) do
-    ~r/#(?<content>.*)\z/
+    ~r/#+(?<content>.*)\z/
     |> Regex.named_captures( content )
     |> case do
       nil -> acc

--- a/test/dogma/rule/comment_format_test.exs
+++ b/test/dogma/rule/comment_format_test.exs
@@ -17,6 +17,16 @@ defmodule Dogma.Rule.CommentFormatTest do
     assert [] == Rule.test( @rule, script )
   end
 
+  should "not error with multiple #s" do
+    script = """
+    ####
+    ## This is cool.
+    ####
+    1 + 1
+    """ |> Script.parse!("")
+    assert [] == Rule.test( @rule, script )
+  end
+
   should "error with not space after the #" do
     script = """
     1 + 1 #Hello, world!

--- a/test/dogma/util/comment_test.exs
+++ b/test/dogma/util/comment_test.exs
@@ -16,6 +16,7 @@ defmodule Dogma.Util.CommentsTest do
 
   should "extract comments" do
     comments = """
+    ### Comments for Foo
     # Very useful.
     defmodule Foo do
       #this is rad.
@@ -25,9 +26,10 @@ defmodule Dogma.Util.CommentsTest do
     end
     """ |> run
     expected = [
-      %Comment{ line: 1, content: " Very useful." },
-      %Comment{ line: 3, content: "this is rad." },
-      %Comment{ line: 6, content: "    # Thuper." },
+      %Comment{ line: 1, content: " Comments for Foo" },
+      %Comment{ line: 2, content: " Very useful." },
+      %Comment{ line: 4, content: "this is rad." },
+      %Comment{ line: 7, content: "    # Thuper." },
     ]
     assert comments == expected
   end


### PR DESCRIPTION
Currently, Dogma raises a `CommentFormat` error for comments that have multiple '`#`' characters before the beginning of the comment eg `## Currently invalid comment`.

This PR modifies the `get_comment` regex to look for one or more `#` characters in succession before the beginning of the comment.

Points of reference in favour of allowing multiple `#` characters before a comment:
- When generating a new Phoenix app, in the `web/channels/user_socket.ex` file, for example, you'll see comments starting with `##` generated from [its template](https://github.com/phoenixframework/phoenix/blob/master/installer/templates/new/web/channels/user_socket.ex)
- Rubocop's leading comment space cop [allows for multiple `#` characters](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/leading_comment_space.rb#L17)
