### PR TITLE
Allow pipe chains to start with a zero-arity function call.

### DIFF
--- a/lib/dogma/rule/pipeline_start.ex
+++ b/lib/dogma/rule/pipeline_start.ex
@@ -82,6 +82,11 @@ defrule Dogma.Rule.PipelineStart do
   defp function_line({:unquote, _, _}),
   do: :ok
 
+  # exception for zero-arity function
+  defp function_line({atom, _, []})
+  when is_atom(atom),
+  do: :ok
+
   defp function_line({atom, meta, args})
   when is_atom(atom) and is_list(args) do
     if atom |> to_string |> String.starts_with?("sigil") do

--- a/test/dogma/rule/pipeline_start_test.exs
+++ b/test/dogma/rule/pipeline_start_test.exs
@@ -224,6 +224,13 @@ defmodule Dogma.Rule.PipelineStartTest do
     assert [] == Rule.test( @rule, script )
   end
 
+  should "not error with a zero-arity function start" do
+    script = """
+    self() |> send(:hello)
+    """ |> Script.parse!("")
+    assert [] == Rule.test( @rule, script )
+  end
+
   should "not error with an interpolated string start" do
     script = ~S"""
     "A #{baked_good}" |> String.upcase |> IO.puts


### PR DESCRIPTION
Fixes #225.