### PR TITLE
Comments: Ignore spacing requirent for shebang line

### DIFF
--- a/lib/dogma/rule/comment_format.ex
+++ b/lib/dogma/rule/comment_format.ex
@@ -26,6 +26,12 @@ defrule Dogma.Rule.CommentFormat do
       "" ->
         errors
 
+      # Allow the 'shebang' line, common in *nix scripts.
+      << "!"::utf8, _::binary >> ->
+        if comment.line == 1,
+          do: errors,
+          else: [error( comment.line ) | errors]
+
       << " "::utf8, _::binary >> ->
         errors
 

--- a/test/dogma/rule/comment_format_test.exs
+++ b/test/dogma/rule/comment_format_test.exs
@@ -38,4 +38,36 @@ defmodule Dogma.Rule.CommentFormatTest do
     """ |> Script.parse!("")
     assert [] == Rule.test( @rule, script )
   end
+
+  test "not error with shebang-style comment as first line" do
+    script = """
+    #!/usr/bin/env elixir
+    1 + 1 # Other stuff here
+    """ |> Script.parse!("")
+    assert [] == Rule.test( @rule, script )
+  end
+
+  test "not error with shebang-style comment as first line, with a space" do
+    script = """
+    #! /usr/bin/env elixir
+    1 + 1 # Other stuff here
+    """ |> Script.parse!("")
+    assert [] == Rule.test( @rule, script )
+  end
+
+  test "error with shebang-style comment not as as first line" do
+    script = """
+    2 + 3
+    #!/usr/bin/env elixir
+    1 + 1 # Other stuff here
+    """ |> Script.parse!("")
+    expected_errors = [
+      %Error{
+        line: 2,
+        message: "Comments should start with a single space",
+        rule: CommentFormat
+      }
+    ]
+    assert expected_errors == Rule.test( @rule, script )
+  end
 end


### PR DESCRIPTION
* The unix shebang line requires the second character to be an exclamation mark, conflicting with the requirement for all comments to be followed by a space.
* This change adds an exception for comments without a leading space provided they occur on the first line of the script, and are immediately followed by an exclamation mark/bang.
* Tests added to support this.

Fixes #231.