### PR TITLE
Remove warnings shown by Elixir 1.4.1

### DIFF
--- a/lib/dogma/config.ex
+++ b/lib/dogma/config.ex
@@ -17,8 +17,8 @@ defmodule Dogma.Config do
   """
   def build do
     %__MODULE__{
-      rules:   get_rules,
-      exclude: get_exclude,
+      rules:   get_rules(),
+      exclude: get_exclude(),
     }
   end
 

--- a/lib/dogma/config.ex
+++ b/lib/dogma/config.ex
@@ -31,7 +31,7 @@ defmodule Dogma.Config do
     rules_map = Enum.reduce( rules, %{}, &insert_rule/2 )
     overrides
     |> Enum.reduce( rules_map, &insert_rule/2 )
-    |> Dict.values
+    |> Map.values
   end
 
   defp get_exclude do
@@ -40,7 +40,7 @@ defmodule Dogma.Config do
 
 
   defp insert_rule(rule, acc) when is_map(rule) do
-    Dict.put(acc, rule.__struct__, rule)
+    Map.put(acc, rule.__struct__, rule)
   end
 
   defp insert_rule({rule_name, config}, acc)
@@ -70,6 +70,6 @@ defmodule Dogma.Config do
 
     https://github.com/lpil/dogma/blob/master/docs/configuration.md
     """
-    Dict.put(acc, rule.__struct__, rule)
+    Map.put(acc, rule.__struct__, rule)
   end
 end

--- a/lib/dogma/documentation/reporters_list.ex
+++ b/lib/dogma/documentation/reporters_list.ex
@@ -9,7 +9,7 @@ defmodule Dogma.Documentation.ReportersList do
   Writes reporter documentation to `docs/reporters.md`.
   """
   def write! do
-    File.write!("docs/reporters.md", reporters_doc)
+    File.write!("docs/reporters.md", reporters_doc())
     IO.puts "Generated docs/reporters.md"
   end
 

--- a/lib/dogma/documentation/rules_list.ex
+++ b/lib/dogma/documentation/rules_list.ex
@@ -1,5 +1,4 @@
 defmodule Dogma.Documentation.RuleList do
-  @shortdoc  "Generate documentation file detailing all rules"
   @moduledoc "Generate documentation file detailing all rules"
 
   def write! do

--- a/lib/dogma/documentation/rules_list.ex
+++ b/lib/dogma/documentation/rules_list.ex
@@ -3,7 +3,7 @@ defmodule Dogma.Documentation.RuleList do
   @moduledoc "Generate documentation file detailing all rules"
 
   def write! do
-    File.write!( "docs/rules.md", rules_doc )
+    File.write!( "docs/rules.md", rules_doc() )
     IO.puts "Generated docs/rules.md"
   end
 
@@ -13,7 +13,7 @@ defmodule Dogma.Documentation.RuleList do
   Gets the information from the `@moduledoc`s of each Rule module.
   """
   def rules_doc do
-    modules  = all_rule_modules
+    modules  = all_rule_modules()
     contents = modules |> Enum.map(&contents_entry/1)
     docs     = modules |> Enum.map(&moduledoc/1) |> Enum.join("\n")
     """

--- a/lib/dogma/reporter/json.ex
+++ b/lib/dogma/reporter/json.ex
@@ -48,7 +48,7 @@ defmodule Dogma.Reporter.JSON do
   """
   def finish(scripts) do
     %{
-      metadata: metadata,
+      metadata: metadata(),
       files: Enum.map(scripts, &format/1),
       summary: summary(scripts)
     } |> Poison.encode!

--- a/lib/dogma/reporter/simple.ex
+++ b/lib/dogma/reporter/simple.ex
@@ -68,13 +68,13 @@ defmodule Dogma.Reporter.Simple do
   end
 
   defp summary(num, 0) do
-    "#{ num } files, #{ IO.ANSI.green }no errors!" <> reset
+    "#{ num } files, #{ IO.ANSI.green }no errors!" <> reset()
   end
   defp summary(num, 1) do
-    "#{ num } files, #{ IO.ANSI.red }1 error!" <> reset
+    "#{ num } files, #{ IO.ANSI.red }1 error!" <> reset()
   end
   defp summary(num, err_count) do
-    "#{ num } files, #{ IO.ANSI.red }#{ err_count } errors!" <> reset
+    "#{ num } files, #{ IO.ANSI.red }#{ err_count } errors!" <> reset()
   end
 
   defp format_errors(scripts) do

--- a/lib/dogma/rule/taken_name.ex
+++ b/lib/dogma/rule/taken_name.ex
@@ -36,9 +36,9 @@ defrule Dogma.Rule.TakenName do
     unquote_splicing update_in use
   )a
 
-  @reserved_words Enum.into(reserved_words, HashSet.new)
+  @reserved_words Enum.into(reserved_words, MapSet.new)
 
-  @spec reserved_words :: HashSet.t
+  @spec reserved_words :: MapSet.t
   def reserved_words do
     @reserved_words
   end
@@ -61,7 +61,7 @@ defrule Dogma.Rule.TakenName do
   end
 
   defp valid_name?(name) do
-    ! HashSet.member?(@reserved_words, name)
+    ! MapSet.member?(@reserved_words, name)
   end
 
   defp check_name(name, meta, ast, errors) when is_atom(name) do

--- a/lib/dogma/rule_set.ex
+++ b/lib/dogma/rule_set.ex
@@ -3,10 +3,8 @@ defmodule Dogma.RuleSet do
   The RuleSet behaviour, used to assert the interface used by our RuleSets
   """
 
-  use Behaviour
-
   @doc """
   Returns the rules and configurations for the set.
   """
-  defcallback rules :: [%{}]
+  @callback rules() :: [%{}]
 end

--- a/lib/dogma/rules.ex
+++ b/lib/dogma/rules.ex
@@ -7,8 +7,6 @@ defmodule Dogma.Rules do
   alias Dogma.Script
   alias Dogma.Runner
 
-  @default_rule_set Dogma.RuleSet.All
-
   @doc """
   Runs the rules in the current rule set on the given scripts.
   """

--- a/lib/dogma/script/comments.ex
+++ b/lib/dogma/script/comments.ex
@@ -35,7 +35,7 @@ defmodule Dogma.Script.Metadata do
 
   defp add_rule_to_index(index, rule, n) do
     rule = "Elixir.#{rule}" |> String.to_atom
-    set  = index |> Dict.get( rule, HashSet.new ) |> Set.put( n )
+    set  = index |> Dict.get( rule, MapSet.new ) |> MapSet.put( n )
     Dict.put( index, rule, set )
   end
 end

--- a/lib/dogma/script/comments.ex
+++ b/lib/dogma/script/comments.ex
@@ -35,7 +35,7 @@ defmodule Dogma.Script.Metadata do
 
   defp add_rule_to_index(index, rule, n) do
     rule = "Elixir.#{rule}" |> String.to_atom
-    set  = index |> Dict.get( rule, MapSet.new ) |> MapSet.put( n )
-    Dict.put( index, rule, set )
+    set  = index |> Map.get( rule, MapSet.new ) |> MapSet.put( n )
+    Map.put( index, rule, set )
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Dogma.Mixfile do
       elixir: "~> 1.3",
       elixirc_paths: elixirc_paths(Mix.env),
       escript: [ main_module: Mix.Tasks.Dogma ],
-      deps: deps,
+      deps: deps(),
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       consolidate_protocols: Mix.env != :test,

--- a/mix.lock
+++ b/mix.lock
@@ -13,5 +13,5 @@
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], []},
   "temporary_env": {:hex, :temporary_env, "1.0.1", "bdb05d9b6c7f782b16779988c83c3f1c2fb2540b902e5e1cf8afbfecbd8e801c", [:mix], []}}

--- a/test/dogma/reporter/flycheck_test.exs
+++ b/test/dogma/reporter/flycheck_test.exs
@@ -9,7 +9,7 @@ defmodule Dogma.Reporter.FlycheckTest do
 
   describe "no errors" do
     setup context do
-      Dict.put(context, :script, [%Script{ errors: [] }])
+      Map.put(context, :script, [%Script{ errors: [] }])
     end
 
     test "output newline to console", context do
@@ -41,7 +41,7 @@ defmodule Dogma.Reporter.FlycheckTest do
         %Script{ path: "baz.ex", errors: [] }
       ]
 
-      Dict.put(context, :script, script)
+      Map.put(context, :script, script)
     end
 
     test "print each error to console", context do

--- a/test/dogma/reporter/json_test.exs
+++ b/test/dogma/reporter/json_test.exs
@@ -90,8 +90,8 @@ defmodule Dogma.Reporter.JSONTest do
     assert metadata == %{
       "dogma_version"       => Dogma.version,
       "elixir_version"      => System.version,
-      "erlang_version"      => erlang_version,
-      "system_architecture" => system_architecture
+      "erlang_version"      => erlang_version(),
+      "system_architecture" => system_architecture()
     }
   end
 

--- a/test/dogma/ruleset/all_test.exs
+++ b/test/dogma/ruleset/all_test.exs
@@ -4,8 +4,6 @@ defmodule Dogma.RuleSet.AllTest do
   alias Dogma.RuleSet.All
 
   describe "rules/0" do
-    @mod_regex ~r/\A[A-Z][A-Za-z\.]+\z/
-
     test "return a module for each file in lib/dogma/rule/" do
       dir_size = "lib/dogma/rule/*.ex" |> Path.wildcard |> length
       set_size = All.rules |> length

--- a/test/dogma/runner_test.exs
+++ b/test/dogma/runner_test.exs
@@ -24,6 +24,6 @@ defmodule Dogma.RunnerTest do
     """ |> Script.parse("")
     refute script.valid?
     results = Runner.run_tests( script, All.rules )
-    assert [%Error{ line: 1, message: _, rule: SyntaxError }] = results
+    assert [%Error{ line: _, message: _, rule: SyntaxError }] = results
   end
 end

--- a/test/dogma/script_sources_test.exs
+++ b/test/dogma/script_sources_test.exs
@@ -5,13 +5,6 @@ defmodule Dogma.ScriptSourcesTest do
   alias Dogma.ScriptSources
 
   @fixture_path "test/fixtures/app/"
-  @fixture_files ~w(
-    test/fixtures/app/config/config.exs
-    test/fixtures/app/lib/app.ex
-    test/fixtures/app/mix.exs
-    test/fixtures/app/test/app_test.exs
-    test/fixtures/app/test/test_helper.exs
-  )
 
   describe "find/2" do
     test "exclude the /deps/ directory" do

--- a/test/dogma/script_test.exs
+++ b/test/dogma/script_test.exs
@@ -163,6 +163,11 @@ defmodule Dogma.ScriptTest do
           ~s(unexpected token: "end". ) <>
           ~s("<<" starting at line 2 is missing terminator ">>")
           or
+        # Elixir 1.4.x has a different error message format
+        message ==
+          ~s("<<" is missing terminator ">>". ) <>
+          ~s(unexpected token: "end" at line 3)
+          or
         # in Elixir 1.0 syntax errors weren't returned correctly
         # https://github.com/elixir-lang/elixir/issues/2993
         message ==

--- a/test/dogma/script_test.exs
+++ b/test/dogma/script_test.exs
@@ -207,8 +207,8 @@ defmodule Dogma.ScriptTest do
       end
       """ |> Script.parse("")
       expected = %{
-        Something     => Enum.into([1], HashSet.new),
-        SomethingElse => Enum.into([1, 2], HashSet.new),
+        Something     => Enum.into([1], MapSet.new),
+        SomethingElse => Enum.into([1, 2], MapSet.new),
       }
       assert script.ignore_index == expected
     end


### PR DESCRIPTION
I noticed various warnings being showed on Elixir 1.4.1 when compiling dogma, as I strive to be warning free I thought I'd take a shot at removing them, most should be uncontroversial but let me know if you think theres a better way to tackle them?

I've broken the commits up to show whats been fixed where.