### PR TITLE
Adding ability to ignore rule on specific line

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ Inspecting 27 files.
 
 How handy!
 
+### Ignoring a rule
+
+Sometimes, you may want to ignore a rule on a specific line.
+This can be accomplished like so:
+
+```elixir
+defmodule Foo do
+  def bar do
+    "baz"; # dogma:ignore Semicolon
+  end
+end
+```
+
 ### Install Dogma globally
 
 In order to run dogma from any directory build the escript:

--- a/lib/dogma/runner.ex
+++ b/lib/dogma/runner.ex
@@ -13,7 +13,71 @@ defmodule Dogma.Runner do
   def run_tests(%Script{} = script, rules) when is_list(rules) do
     rules
     |> Enum.filter(&(&1.enabled))
-    |> Enum.map( &Rule.test(&1, script) )
+    |> Enum.map(fn rule ->
+         filtered_script = filter_script(script, rule)
+
+         Rule.test(rule, filtered_script)
+       end)
     |> List.flatten
+  end
+
+  defp filter_script(script, rule) do
+    rule_name = rule_name(rule)
+
+    %Dogma.Script{script |
+      lines: filter_lines(script, rule_name),
+      processed_lines: filter_processed_lines(script, rule_name),
+      tokens: filter_tokens(script, rule_name)
+    }
+  end
+
+  defp filter_lines(script, rule_name) do
+    script.lines
+    |> Enum.with_index
+    |> Enum.filter(&(!line_ignored(&1, script.ignore_index, rule_name)))
+    |> Enum.map(fn {line, _index} -> line end)
+  end
+
+  defp filter_processed_lines(script, rule_name) do
+    script.processed_lines
+    |> Enum.with_index
+    |> Enum.filter(&(!line_ignored(&1, script.ignore_index, rule_name)))
+    |> Enum.map(fn {line, _index} -> line end)
+  end
+
+  defp filter_tokens(script, rule_name) do
+    script.tokens
+    |> Enum.filter(fn token ->
+      case token do
+        {_, {line_number, _, _},_} ->
+          !line_ignored(line_number, script.ignore_index, rule_name)
+        {_, {line_number, _, _}} ->
+          !line_ignored(line_number, script.ignore_index, rule_name)
+        _ ->
+          true
+      end
+    end)
+  end
+
+  defp line_ignored(line_number, ignore_index, rule_name)
+    when is_number(line_number)
+  do
+    ignore_index
+    |> Map.get(rule_name, MapSet.new())
+    |> MapSet.member?(line_number)
+  end
+  defp line_ignored({_, index}, ignore_index, rule_name) do
+    line_number = index + 1
+
+    line_ignored(line_number, ignore_index, rule_name)
+  end
+
+  defp rule_name(rule) do
+    rule.__struct__
+    |> Atom.to_string
+    |> String.split(".")
+    |> List.last
+    |> String.replace_prefix("", "Elixir.")
+    |> String.to_atom
   end
 end

--- a/test/dogma/runner_test.exs
+++ b/test/dogma/runner_test.exs
@@ -7,23 +7,145 @@ defmodule Dogma.RunnerTest do
   alias Dogma.Script
   alias Dogma.Config
 
-  test "run_tests/2 run the given rules" do
-    errors =
-      "1 + 1\n"
-      |> Script.parse!("foo.ex")
-      |> Runner.run_tests(Config.build.rules)
-    assert [] == errors
-  end
-
-  test "syntax errors don't run tests or cause crashes" do
-    script = """
-    defmodule DoclessModule do
-      def foo) do # Syntax error here
-      end
+  describe "run_tests/2" do
+    test "runs the given rules" do
+      errors =
+        "1 + 1\n"
+        |> Script.parse!("foo.ex")
+        |> Runner.run_tests(Config.build.rules)
+      assert [] == errors
     end
-    """ |> Script.parse("")
-    refute script.valid?
-    results = Runner.run_tests( script, All.rules )
-    assert [%Error{ line: _, message: _, rule: SyntaxError }] = results
+
+    test "returns error for rule that uses lines" do
+      content =
+        "a lonnnnnnnnnnnnnnnnnnnnnnnggggggggggggggggggggggggggggggggggggg"
+        <> " liiiiiiiiiiinnnnnnnnnneeeeeeeeeeeeeeee\n"
+
+      errors =
+        content
+        |> Script.parse!("foo.ex")
+        |> Runner.run_tests(Config.build.rules)
+
+      assert [
+        %Dogma.Error{
+          line: 1,
+          message: "Line length should not exceed 80 chars (was 103).",
+          rule: Dogma.Rule.LineLength
+        }
+      ] == errors
+    end
+
+    test "returns surfaces error for rule that uses processed_lines" do
+      errors =
+        "a line with trailing whitespace    \n"
+        |> Script.parse!("foo.ex")
+        |> Runner.run_tests(Config.build.rules)
+
+      assert [
+        %Dogma.Error{
+          line: 1,
+          message: "Trailing whitespace detected",
+          rule: Dogma.Rule.TrailingWhitespace
+        }
+      ] == errors
+    end
+
+    test "returns error for rule that uses tokens" do
+      content =
+        "a line with a semicolon;\n"
+        <> "another line without a semicolon\n"
+
+      errors =
+        content
+        |> Script.parse!("foo.ex")
+        |> Runner.run_tests(Config.build.rules)
+
+      assert [
+        %Dogma.Error{
+          line: 1,
+          message: "Expressions should not be terminated by semicolons.",
+          rule: Dogma.Rule.Semicolon
+        }
+      ] == errors
+    end
+
+    test "ignores rule that uses lines" do
+      content =
+        "a lonnnnnnnnnnnnnnnnnnnnnnnggggggggggggggggggggggggggggggggggggg"
+        <> " liiiiiiiiiiinnnnnnnnnneeeeeeeeeeeeeeee # dogma:ignore LineLength\n"
+
+      errors =
+        content
+        |> Script.parse!("foo.ex")
+        |> Runner.run_tests(Config.build.rules)
+
+      assert [] == errors
+    end
+
+    test "ignores rule that uses processed_lines" do
+      errors =
+        "a line with trailing whitespace    # dogma:ignore TrailingWhitespace\n"
+        |> Script.parse!("foo.ex")
+        |> Runner.run_tests(Config.build.rules)
+
+      assert [] == errors
+    end
+
+    test "ignores rule that uses tokens" do
+      content =
+        "a line with a semicolon; # dogma:ignore Semicolon\n"
+        <> "another line without a semicolon\n"
+
+      errors =
+        content
+        |> Script.parse!("foo.ex")
+        |> Runner.run_tests(Config.build.rules)
+
+      assert [] == errors
+    end
+
+    test "ignores ignored rule, but not other rule" do
+      content =
+        "a longgggggggggggggggggggggggggggggggggggggggggggggggggggggg"
+        <> " line with a semicolon; # dogma:ignore LineLength\n"
+
+      errors =
+        content
+        |> Script.parse!("foo.ex")
+        |> Runner.run_tests(Config.build.rules)
+
+      assert [
+        %Dogma.Error{
+          line: 1,
+          message: "Expressions should not be terminated by semicolons.",
+          rule: Dogma.Rule.Semicolon
+        }
+      ] == errors
+    end
+
+    test "ignores multiple rules" do
+      content =
+        "a longgggggggggggggggggggggggggggggggggggggggggggggggggggggg"
+        <> " line with a semicolon; # dogma:ignore LineLength Semicolon\n"
+
+      errors =
+        content
+        |> Script.parse!("foo.ex")
+        |> Runner.run_tests(Config.build.rules)
+
+      assert [] == errors
+    end
+
+    test "doesn't run test or cause crashes when there are syntax errors" do
+      script = """
+      defmodule DoclessModule do
+        def foo) do # Syntax error here
+        end
+      end
+      """ |> Script.parse("")
+      refute script.valid?
+      results = Runner.run_tests( script, All.rules )
+      assert [%Error{ line: _, message: _, rule: SyntaxError }] = results
+    end
   end
 end


### PR DESCRIPTION
It looks like work was already started on this with
b7d150c9b76b1cccf338931c2addc6d370b2e0f7. Using the Script.ignore_index
introduced with that commit to ignore specific rules on certain lines.