### PR TITLE
Ignore assets/node_modules .

### DIFF
--- a/lib/dogma/script_sources.ex
+++ b/lib/dogma/script_sources.ex
@@ -9,6 +9,7 @@ defmodule Dogma.ScriptSources do
   @ignored_dirs ~w(
     deps/
     _build/
+    assets/node_modules/
   )
 
   @doc """

--- a/test/dogma/script_sources_test.exs
+++ b/test/dogma/script_sources_test.exs
@@ -24,7 +24,7 @@ defmodule Dogma.ScriptSourcesTest do
     end
 
     test "not return files that match given exclude patterns" do
-      patterns = [~r(config/), ~r(app/test/), ~r(_build/)]
+      patterns = [~r(config/), ~r(app/test/), ~r(_build/), ~r(assets/node_modules/)]
       paths    = ScriptSources.find( @fixture_path, patterns )
       expected = ~w(
         test/fixtures/app/lib/app.ex

--- a/test/dogma/script_sources_test.exs
+++ b/test/dogma/script_sources_test.exs
@@ -24,7 +24,8 @@ defmodule Dogma.ScriptSourcesTest do
     end
 
     test "not return files that match given exclude patterns" do
-      patterns = [~r(config/), ~r(app/test/), ~r(_build/), ~r(assets/node_modules/)]
+      patterns = [~r(config/), ~r(app/test/),
+                  ~r(_build/), ~r(assets/node_modules/)]
       paths    = ScriptSources.find( @fixture_path, patterns )
       expected = ~w(
         test/fixtures/app/lib/app.ex

--- a/test/fixtures/app/assets/node_modules/dep.ex
+++ b/test/fixtures/app/assets/node_modules/dep.ex
@@ -1,0 +1,3 @@
+defmodule Dep do
+
+end


### PR DESCRIPTION
Addresses issue #248 

One problem that I found is that the tests are a little bit off.
`script_sources_test.exs` uses the `test/fixtures/app` to test, but when getting the path through `@fixture_path`, the line `|> Enum.reject( &String.starts_with?(&1, @ignored_dirs) )` in `script_sources.ex` doesn't match the paths to be ignored because it comes with the `test/fixtures/app` at the beginning, so it's not "properly tested".
I'm not sure how to refactor the tests to reflect that.