### PR TITLE
Add configuration allow_multiple_hashes to CommentFormat

### DIFF
--- a/lib/dogma/rule/comment_format.ex
+++ b/lib/dogma/rule/comment_format.ex
@@ -16,8 +16,6 @@ defrule Dogma.Rule.CommentFormat, [allow_multiple_hashes: true] do
       #Hello, world!
   """
 
-  alias Dogma.Util.Comment
-
   def test(rule, script) do
     script.comments
     |> Enum.reduce([], fn comment, errors ->
@@ -47,7 +45,7 @@ defrule Dogma.Rule.CommentFormat, [allow_multiple_hashes: true] do
 
   defp hashes_error?(content, allow_multiple_hashes)
   defp hashes_error?("", _), do: false
-  defp hashes_error?(<< " "::utf8, rest::binary >>, true), do: false
+  defp hashes_error?(<< " "::utf8, _::binary >>, true), do: false
   defp hashes_error?(<< "#"::utf8, rest::binary >>, true) do
     hashes_error?(rest, true)
   end

--- a/lib/dogma/rule/comment_format.ex
+++ b/lib/dogma/rule/comment_format.ex
@@ -33,7 +33,8 @@ defrule Dogma.Rule.CommentFormat, [allow_multiple_hashes: true] do
     case comment.content do
       "" -> false
 
-      << "#"::utf8, rest::binary >> -> hashes_error?(rest, allow_multiple_hashes)
+      << "#"::utf8, rest::binary >> ->
+        hashes_error?(rest, allow_multiple_hashes)
 
       # Allow the 'shebang' line, common in *nix scripts.
       << "!"::utf8, _::binary >> -> comment.line != 1

--- a/test/dogma/rule/comment_format_test.exs
+++ b/test/dogma/rule/comment_format_test.exs
@@ -41,6 +41,21 @@ defmodule Dogma.Rule.CommentFormatTest do
     assert [] == Rule.test( @rule, script )
   end
 
+  test "error with multiple #'s followed by non-whitespace" do
+    script = """
+    ####
+    ##This is not cool.
+    """ |> Script.parse!("")
+    expected_errors = [
+      %Error{
+        line: 2,
+        message: "Comments should start with a single space",
+        rule: CommentFormat
+      }
+    ]
+    assert expected_errors == Rule.test( @rule, script )
+  end
+
   test "error with multiple #'s without allow_multiple_hashes" do
     rule = %CommentFormat{ allow_multiple_hashes: false }
     script = """

--- a/test/dogma/rule/comment_format_test.exs
+++ b/test/dogma/rule/comment_format_test.exs
@@ -31,6 +31,33 @@ defmodule Dogma.Rule.CommentFormatTest do
     assert expected_errors == Rule.test( @rule, script )
   end
 
+  test "not error with multiple #'s with allow_multiple_hashes" do
+    script = """
+    ####
+    ## This is cool.
+    ####
+    1 + 1
+    """ |> Script.parse!("")
+    assert [] == Rule.test( @rule, script )
+  end
+
+  test "error with multiple #'s without allow_multiple_hashes" do
+    rule = %CommentFormat{ allow_multiple_hashes: false }
+    script = """
+    ## This is not cool.
+    1 + 1
+    """ |> Script.parse!("")
+
+    expected_errors = [
+      %Error{
+        line: 1,
+        message: "Comments should start with a single space",
+        rule: CommentFormat
+      }
+    ]
+    assert expected_errors == Rule.test( rule, script )
+  end
+
   test "not error with not multiple spaces after the #" do
     script = """
     "Hi!"


### PR DESCRIPTION
(this is a reimplementation of #222)

Currently, Dogma raises a CommentFormat error for comments that have multiple '`#`' characters before the beginning of the comment eg `## Currently invalid comment`.

This PR adds an `allow_multiple_hashes` configuration to the `CommentFormat` rule that allows multiple `#` at the beginning of a comment.

Points of reference in favour of allowing multiple # characters before a comment:

* When generating a new Phoenix app, in the web/channels/user_socket.ex file, for example, you'll see comments starting with ## generated from its template
* Rubocop's leading comment space cop allows for multiple # characters

