### PR TITLE
Missing clause bug

### DIFF
--- a/lib/dogma/rule/infix_operator_padding.ex
+++ b/lib/dogma/rule/infix_operator_padding.ex
@@ -75,6 +75,7 @@ defrule Dogma.Rule.InfixOperatorPadding,
   defp normalize_token({a, {b, c, d}, e}), do: {a, b, c, d, e}
   defp normalize_token({a, {b, c, d}, e, _}), do: {a, b, c, d, e}
   defp normalize_token({a, {b, c, d}, e, _, _}), do: {a, b, c, d, e}
+  defp normalize_token({a, {b, c, d}, e, _, _, _}), do: {a, b, c, d, e}
 
   defp check_operators(tokens, rule, acc \\ [])
 

--- a/lib/dogma/script.ex
+++ b/lib/dogma/script.ex
@@ -105,6 +105,7 @@ defmodule Dogma.Script do
     case result do
       {:ok, _, tokens}    -> tokens # Elixir 1.0.x
       {:ok, _, _, tokens} -> tokens # Elixir 1.1.x
+      {:ok, tokens} -> tokens
     end
   end
 

--- a/test/dogma/rule/infix_operator_padding_test.exs
+++ b/test/dogma/rule/infix_operator_padding_test.exs
@@ -146,6 +146,13 @@ defmodule Dogma.Rule.InfixOperatorPaddingTest do
       assert [infix_error(1)] == Rule.test(rule, script)
     end
 
+    test "sigil clause dont match with new elixir release" do
+      script = "\~S(test)"
+      result = {:sigil_S, [line: 1], [{:<<>>, [line: 1], ["test"]}, []]}
+      %{ ast: ast } = script |> Script.parse("")
+      assert(ast == result)
+    end
+    
   end
 
 end


### PR DESCRIPTION
Hi,

I actually have an issue with Dogma on last elixir release (1.8.1) running on Erlang/OTP 21.

```
** (CaseClauseError) no case clause matching: {:ok, [{:identifier, {1, 1, nil}, :defmodule}, {:alias, {1, 11, nil}, :Dogma}, {:., {1, 16, nil}}, {:alias, {1, 17, nil}, :RulesRunBench}, {:do, {1, 31, nil}}, {:eol, {1, 33, 1}}
, {:identifier, {2, 3, nil}, :use}, {:alias, {2, 7, nil}, :Benchfella}, {:eol, {2, 17, 2}}, {:identifier, {4, 3, nil}, :alias}, {:alias, {4, 9, nil}, :Dogma}, {:., {4, 14, nil}}, {:alias, {4, 15, nil}, :Rules}, {:eol, {4, 20
, 1}}, {:identifier, {5, 3, nil}, :alias}, {:alias, {5, 9, nil}, :Dogma}, {:., {5, 14, nil}}, {:alias, {5, 15, nil}, :ScriptSources}, {:eol, {5, 28, 2}}, {:at_op, {7, 3, nil}, :@}, {:identifier, {7, 4, nil}, :sample_script_p
ath}, {:bin_string, {7, 23, nil}, [""]}, {:eol, {7, 25, 2}}, {:identifier, {9, 3, nil}, :bench}, {:bin_string, {9, 9, nil}, ["1 file"]}, {:",", {9, 17, 0}}, {:"[", {9, 19, nil}}, {:kw_identifier, {9, 20, nil}, :scripts}, {:p
aren_identifier, {9, 29, nil}, :get_scripts}, {:"(", {9, 40, nil}}, {:int, {9, 41, 1}, '1'}, {:")", {9, 42, nil}}, {:"]", {9, 43, nil}}, {:do, {9, 45, nil}}, {:eol, {9, 47, 1}}, {:identifier, {10, 5, nil}, :scripts}, {:arrow
_op, {10, 13, nil}, :|>}, {:identifier, {10, 16, nil}, :run}, {:eol, {10, 19, 1}}, {:end, {11, 3, nil}}, {:eol, {11, 6, 2}}, {:identifier, {13, 3, nil}, :bench}, {:bin_string, {13, 9, nil}, ["5 files"]}, {:",", {13, 18, ...}
}, {:"[", {13, ...}}, {:kw_identifier, {...}, ...}, {:paren_identifier, ...}, {...}, ...]}
    lib/dogma/script.ex:105: Dogma.Script.tokenize/1
    lib/dogma/script.ex:81: Dogma.Script.add_tokens/1
    lib/dogma/script.ex:48: Dogma.Script.parse/2
    lib/dogma/script_sources.ex:42: anonymous fn/2 in Dogma.ScriptSources.to_scripts/1
    (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3
    lib/dogma/script_sources.ex:39: Dogma.ScriptSources.to_scripts/1
    lib/dogma.ex:23: Dogma.run/3
    lib/mix/tasks/dogma.ex:25: Mix.Tasks.Dogma.main/1
```

This impact two files, the first one is `lib/dogma/script.ex` and we should a new pattern matching. The other one is present in `lib/dogma/rule/infix_operator_padding.ex`. This last one crash with this tuple:

```
{:sigil, {24, 10, nil}, 83, ["no-op with =~"], [], "{"}}
```

It seems that last elixir version add a new way to answer with tokens (a longer tuple). I made this patch with a small test.  Please tell me if you are agree with this patch and/or you have same issues on your side.

